### PR TITLE
chore(all): tune release channel naming

### DIFF
--- a/sdks/permit2-sdk/package.json
+++ b/sdks/permit2-sdk/package.json
@@ -42,6 +42,7 @@
     "branches": [
       {
         "name": "main",
+        "channel": "beta",
         "prerelease": true
       }
     ],

--- a/sdks/router-sdk/package.json
+++ b/sdks/router-sdk/package.json
@@ -44,6 +44,7 @@
     "branches": [
       {
         "name": "main",
+        "channel": "beta",
         "prerelease": true
       }
     ],

--- a/sdks/sdk-core/package.json
+++ b/sdks/sdk-core/package.json
@@ -49,6 +49,7 @@
     "branches": [
       {
         "name": "main",
+        "channel": "beta",
         "prerelease": true
       }
     ],

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -68,6 +68,7 @@
     "branches": [
       {
         "name": "main",
+        "channel": "alpha",
         "prerelease": true
       }
     ],

--- a/sdks/universal-router-sdk/package.json
+++ b/sdks/universal-router-sdk/package.json
@@ -69,6 +69,7 @@
     "branches": [
       {
         "name": "main",
+        "channel": "beta",
         "prerelease": true
       }
     ],

--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -50,6 +50,7 @@
     "branches": [
       {
         "name": "main",
+        "channel": "beta",
         "prerelease": true
       }
     ],

--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -58,6 +58,7 @@
     "branches": [
       {
         "name": "main",
+        "channel": "beta",
         "prerelease": true
       }
     ],


### PR DESCRIPTION
## Description

Ensures each SDK has the right channel name before publishing. This will ensure all versions are named -beta.<build number> until we test fully and increase these.

Note that `uniswapx-sdk` is already using alpha, so we will continue with that since it is already officially alpha software.

Docs: https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#branches-properties

## How Has This Been Tested?
- will test when publishing beta versions