### PR TITLE
chore(release): publish v2-sdk, v3-sdk, and uniswapx-sdk after testing (2/4)

### DIFF
--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
-    "@uniswap/permit2-sdk": "^1.2.1-beta.1",
-    "@uniswap/sdk-core": "^4.2.1-beta.1",
+    "@uniswap/permit2-sdk": "^1.2.1",
+    "@uniswap/sdk-core": "^4.2.1",
     "ethers": "^5.7.0"
   },
   "devDependencies": {
@@ -71,7 +71,7 @@
         "prerelease": false
       },
       {
-        "name": "wont-release-yet",
+        "name": "main",
         "prerelease": true
       }
     ],

--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ethersproject/address": "^5.0.2",
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^4.2.1-beta.1",
+    "@uniswap/sdk-core": "^4.2.1",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },
@@ -49,7 +49,7 @@
     "extends": "semantic-release-monorepo",
     "branches": [
       {
-        "name": "wont-release-yet",
+        "name": "main",
         "prerelease": false
       }
     ],

--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^4.2.1-beta.1",
+    "@uniswap/sdk-core": "^4.2.1",
     "@uniswap/swap-router-contracts": "^1.3.0",
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-staker": "1.0.0",
@@ -57,7 +57,7 @@
     "extends": "semantic-release-monorepo",
     "branches": [
       {
-        "name": "wont-release-yet",
+        "name": "main",
         "prerelease": false
       }
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4580,6 +4580,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uniswap/permit2-sdk@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@uniswap/permit2-sdk@npm:1.2.1"
+  dependencies:
+    ethers: ^5.7.0
+    tiny-invariant: ^1.1.0
+  checksum: 7c4fcc0aaa6e53da0f01c25984b7b37aaf95aa43479a2f374d5867956033ed34d9477b31aa1c0998c51ae3af28ab5dd2902c97f2acd176dac6dfed171ca5b6a4
+  languageName: node
+  linkType: hard
+
 "@uniswap/permit2-sdk@npm:^1.2.1-beta.1":
   version: 1.2.1-beta.1
   resolution: "@uniswap/permit2-sdk@npm:1.2.1-beta.1"
@@ -4629,6 +4639,20 @@ __metadata:
     tsdx: ^0.14.1
   languageName: unknown
   linkType: soft
+
+"@uniswap/sdk-core@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@uniswap/sdk-core@npm:4.2.1"
+  dependencies:
+    "@ethersproject/address": ^5.0.2
+    big.js: ^5.2.2
+    decimal.js-light: ^2.5.0
+    jsbi: ^3.1.4
+    tiny-invariant: ^1.1.0
+    toformat: ^2.0.0
+  checksum: a72b85e7fafe787a0cb2215cab5f7981fb18c1f63b58a3257accbefe0cc8fd64b7ad99d6ae9d0fc12f4383ac90d3991bae49a6af1fc5c89b72e1a9132af2c8e5
+  languageName: node
+  linkType: hard
 
 "@uniswap/sdk-core@npm:^4.2.1-beta.1":
   version: 4.2.1-beta.1
@@ -4685,8 +4709,8 @@ __metadata:
     "@types/node": ^18.7.16
     "@typescript-eslint/eslint-plugin": ^5.62
     "@typescript-eslint/parser": ^5.62
-    "@uniswap/permit2-sdk": ^1.2.1-beta.1
-    "@uniswap/sdk-core": ^4.2.1-beta.1
+    "@uniswap/permit2-sdk": ^1.2.1
+    "@uniswap/sdk-core": ^4.2.1
     eslint: ^7.8.0
     eslint-config-prettier: ^6.11.0
     eslint-plugin-eslint-comments: ^3.2.0
@@ -4773,7 +4797,7 @@ __metadata:
     "@ethersproject/solidity": ^5.0.9
     "@types/big.js": ^4.0.5
     "@types/jest": ^24.0.25
-    "@uniswap/sdk-core": ^4.2.1-beta.1
+    "@uniswap/sdk-core": ^4.2.1
     "@uniswap/v2-core": ^1.0.1
     eslint-config-react-app: 7.0.1
     tiny-invariant: ^1.1.0
@@ -4832,7 +4856,7 @@ __metadata:
     "@ethersproject/abi": ^5.5.0
     "@ethersproject/solidity": ^5.0.9
     "@types/jest": ^24.0.25
-    "@uniswap/sdk-core": ^4.2.1-beta.1
+    "@uniswap/sdk-core": ^4.2.1
     "@uniswap/swap-router-contracts": ^1.3.0
     "@uniswap/v3-core": 1.0.0
     "@uniswap/v3-periphery": ^1.1.1


### PR DESCRIPTION
## Description

Followup 2/4 from https://github.com/Uniswap/sdks/pull/5

Covers the following SDK's:
- `v2-sdk`
- `v3-sdk`
- `uniswapx-sdk`