### PR TITLE
chore(release): fix alpha channel for uniswapx-sdk and remove push to beta

### DIFF
--- a/.github/workflows/push-branches-from-main.yaml
+++ b/.github/workflows/push-branches-from-main.yaml
@@ -22,10 +22,6 @@ jobs:
           git config user.name "UL Mobile Service Account"
           git config user.email "hello-happy-puppy@users.noreply.github.com"
 
-      - name: ↗️  Push to beta
-        run: |
-          git push -u origin main:beta --force
-
       - name: ↗️  Push to alpha
         run: |
           git push -u origin main:alpha --force

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -71,7 +71,7 @@
         "prerelease": false
       },
       {
-        "name": "main",
+        "name": "alpha",
         "prerelease": true
       }
     ],


### PR DESCRIPTION
## Description

- Ensures `uniswapx-sdk` still publishes to the alpha channel
- Removes pushing to beta as the channel is no longer being used