### PR TITLE
chore(release): autopublishing from main and beta + uniswapx-sdk to beta

### DIFF
--- a/.github/workflows/push-branches-from-main.yaml
+++ b/.github/workflows/push-branches-from-main.yaml
@@ -22,6 +22,6 @@ jobs:
           git config user.name "UL Mobile Service Account"
           git config user.email "hello-happy-puppy@users.noreply.github.com"
 
-      - name: ↗️  Push to alpha
+      - name: ↗️  Push to beta
         run: |
-          git push -u origin main:alpha --force
+          git push -u origin main:beta --force

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,7 +1,10 @@
 name: Release
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - beta
 
 jobs:
   release:

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -71,7 +71,7 @@
         "prerelease": false
       },
       {
-        "name": "alpha",
+        "name": "beta",
         "prerelease": true
       }
     ],


### PR DESCRIPTION
## Description

- Automatically publishes on push to main or beta based on commit messages (PR scope/titles)
- Pushes to beta, not alpha as alpha has issues properly keeping up its version
- Updates `uniswapx-sdk` to publish as beta
