### PR TITLE
chore(release): fix breaking change marker

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Please title your PR according to the following types and scopes following [conv
 - `chore(<type>):` will not trigger any release and should be used for internal repo changes
 - `<type>(public):` will trigger a patch version for non-code changes (e.g. README changes)
 - `feat(SDK name):` will trigger a minor version
-- `feat(!):` will trigger a major version for a breaking change
+- `feat(breaking):` will trigger a major version for a breaking change
 
 ## Description
 
@@ -20,7 +20,7 @@ _[e.g. Manually, E2E tests, unit tests, Storybook]_
 
 _[e.g. Type definitions, API definitions]_
 
-If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(!): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.
+If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.
 
 ## (Optional) Feedback Focus
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Publishing of each SDK is done on merge to main using semantic-release and seman
 - `fix(SDK name):` will trigger a patch version
 - `<type>(public):` will trigger a patch version
 - `feat(SDK name):` will trigger a minor version
-- `feat(!):` will trigger a major version for a breaking change
+- `feat(breaking):` will trigger a major version for a breaking change
 ```
 
 Versions will only be generated based on the changelog of the relevant SDK's folder/files.

--- a/publishing/release-rules.cjs
+++ b/publishing/release-rules.cjs
@@ -1,4 +1,4 @@
 module.exports = [
-  { type: "feat", scope: "!", release: "major" },
+  { type: "feat", scope: "breaking", release: "major" },
   { scope: "public", release: "patch" },
 ];


### PR DESCRIPTION
## Description

Due to rules being a glob, the `!` marker was treated as a negation and accidentally treated all minor version bumps as major. This removes that possibility!