### PR TITLE
fix(v2-sdk, v3-sdk, uniswapx-sdk): update sdk-core dependency version

### DIFF
--- a/sdks/uniswapx-sdk/integration/package.json
+++ b/sdks/uniswapx-sdk/integration/package.json
@@ -31,7 +31,7 @@
     "@ethersproject/bytes": "^5.7.0",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.2",
-    "@uniswap/sdk-core": "^4.2.1",
+    "@uniswap/sdk-core": "^5.0.0",
     "ethers": "^5.7.0",
     "typechain": "^8.1.0"
   }

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -31,7 +31,7 @@
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@uniswap/permit2-sdk": "^1.2.1",
-    "@uniswap/sdk-core": "^4.2.1",
+    "@uniswap/sdk-core": "^5.0.0",
     "ethers": "^5.7.0"
   },
   "devDependencies": {

--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ethersproject/address": "^5.0.2",
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^4.2.1",
+    "@uniswap/sdk-core": "^5.0.0",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },

--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^4.2.1",
+    "@uniswap/sdk-core": "^5.0.0",
     "@uniswap/swap-router-contracts": "^1.3.0",
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-staker": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4644,6 +4644,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uniswap/sdk-core@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@uniswap/sdk-core@npm:5.0.0"
+  dependencies:
+    "@ethersproject/address": ^5.0.2
+    big.js: ^5.2.2
+    decimal.js-light: ^2.5.0
+    jsbi: ^3.1.4
+    tiny-invariant: ^1.1.0
+    toformat: ^2.0.0
+  checksum: 06a4b9ccec3e19bdf695011999c4039a0477910ad5e4128efd8a06e44c23fb40d3685ef5ef2d520632562fe4d0fa486d01326b391266e8e08f43dfc522bd41d5
+  languageName: node
+  linkType: hard
+
 "@uniswap/sdk-core@workspace:sdks/sdk-core":
   version: 0.0.0-use.local
   resolution: "@uniswap/sdk-core@workspace:sdks/sdk-core"
@@ -4686,7 +4700,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.62
     "@typescript-eslint/parser": ^5.62
     "@uniswap/permit2-sdk": ^1.2.1
-    "@uniswap/sdk-core": ^4.2.1
+    "@uniswap/sdk-core": ^5.0.0
     eslint: ^7.8.0
     eslint-config-prettier: ^6.11.0
     eslint-plugin-eslint-comments: ^3.2.0
@@ -4773,7 +4787,7 @@ __metadata:
     "@ethersproject/solidity": ^5.0.9
     "@types/big.js": ^4.0.5
     "@types/jest": ^24.0.25
-    "@uniswap/sdk-core": ^4.2.1
+    "@uniswap/sdk-core": ^5.0.0
     "@uniswap/v2-core": ^1.0.1
     eslint-config-react-app: 7.0.1
     tiny-invariant: ^1.1.0
@@ -4832,7 +4846,7 @@ __metadata:
     "@ethersproject/abi": ^5.5.0
     "@ethersproject/solidity": ^5.0.9
     "@types/jest": ^24.0.25
-    "@uniswap/sdk-core": ^4.2.1
+    "@uniswap/sdk-core": ^5.0.0
     "@uniswap/swap-router-contracts": ^1.3.0
     "@uniswap/v3-core": 1.0.0
     "@uniswap/v3-periphery": ^1.1.1
@@ -17818,7 +17832,7 @@ __metadata:
     "@types/chai": ^4.3.3
     "@types/mocha": ^9.1.1
     "@types/node": ^18.7.16
-    "@uniswap/sdk-core": ^4.2.1
+    "@uniswap/sdk-core": ^5.0.0
     chai: ^4.3.6
     ethers: ^5.7.0
     hardhat: ^2.14.0


### PR DESCRIPTION
## Description

Updates the SDK core dependency (needed due to the unintentional major version bump, non-breaking)

## How Has This Been Tested?
- testing done on https://github.com/Uniswap/sdks/pull/11

## (Optional) Follow Ups

This will be done in `router-sdk` and then `universal-router-sdk` once each step has been published
