### PR TITLE
chore(infra): sets up the npm deploy job to use the github runner

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -11,7 +11,8 @@ jobs:
     name: Release
     environment:
       name: production
-    runs-on: ubuntu-latest
+    runs-on: 
+      group: npm-deploy
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
@@ -38,7 +39,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          NPM_TOKEN: op://sdk-npm-deploys/npm-token/secret
+          NPM_TOKEN: op://npm-deploy/npm-runner-token/secret
 
       - name: Release Needed SDK's
         env:


### PR DESCRIPTION
## Description

Updates the npm token and sets it to use the runner. When this gets merged I need to rotate the vault token (takes 30 seconds)
