### PR TITLE
fix(router-sdk): Address wrapped/native currency conditions in mixed routes with v4

### DIFF
--- a/sdks/router-sdk/src/entities/mixedRoute/route.test.ts
+++ b/sdks/router-sdk/src/entities/mixedRoute/route.test.ts
@@ -72,13 +72,39 @@ describe('MixedRoute', () => {
       expect(route.chainId).toEqual(1)
     })
 
-    it('wraps mixed route object with v4 route successfully constructs a pth from the tokens', () => {
+    it('wraps mixed route object with v4 route successfully constructs a path from the tokens', () => {
       const route = new MixedRouteSDK([pool_v3_0_1, pool_v4_0_weth], token1, weth)
       expect(route.pools).toEqual([pool_v3_0_1, pool_v4_0_weth])
       expect(route.path).toEqual([token1, token0, weth])
       expect(route.input).toEqual(token1)
       expect(route.output).toEqual(weth)
       expect(route.chainId).toEqual(1)
+    })
+
+    it('wraps mixed route object with mixed v4 route that converts WETH -> ETH ', () => {
+      const route = new MixedRouteSDK([pool_v3_0_weth, pool_v4_1_eth], token0, token1)
+      expect(route.pools).toEqual([pool_v3_0_weth, pool_v4_1_eth])
+      expect(route.path).toEqual([token0, weth, token1])
+      expect(route.input).toEqual(token0)
+      expect(route.output).toEqual(token1)
+      expect(route.chainId).toEqual(1)
+    })
+
+    it('wraps mixed route object with mixed v4 route that converts ETH -> WETH ', () => {
+      const route = new MixedRouteSDK([pool_v4_1_eth, pool_v3_0_weth], token1, token0)
+      expect(route.pools).toEqual([pool_v4_1_eth, pool_v3_0_weth])
+      expect(route.path).toEqual([token1, ETHER, token0])
+      expect(route.input).toEqual(token1)
+      expect(route.output).toEqual(token0)
+      expect(route.chainId).toEqual(1)
+    })
+
+    it('cannot wrap mixed route object with pure v4 route that converts ETH -> WETH ', () => {
+      expect(() => new MixedRouteSDK([pool_v4_1_eth, pool_v4_0_weth], token1, token0)).toThrow('PATH')
+    })
+
+    it('cannot wrap mixed route object with pure v4 route that converts WETH -> ETH ', () => {
+      expect(() => new MixedRouteSDK([pool_v4_0_weth, pool_v4_1_eth], token0, token1)).toThrow('PATH')
     })
 
     it('wraps complex mixed route object and successfully constructs a path from the tokens', () => {

--- a/sdks/router-sdk/src/entities/mixedRoute/trade.test.ts
+++ b/sdks/router-sdk/src/entities/mixedRoute/trade.test.ts
@@ -57,6 +57,16 @@ describe('MixedRouteTrade', () => {
     CurrencyAmount.fromRawAmount(WETH9[1], 130000),
     true
   )
+  const pool_v4_0_eth = v2StylePool(
+    CurrencyAmount.fromRawAmount(token0, 120000),
+    CurrencyAmount.fromRawAmount(ETHER, 130000),
+    true
+  )
+  // const pool_v4_1_eth = v2StylePool(
+  //   CurrencyAmount.fromRawAmount(token1, 120000),
+  //   CurrencyAmount.fromRawAmount(ETHER, 130000),
+  //   true
+  // )
 
   const pool_v3_0_1 = v2StylePool(
     CurrencyAmount.fromRawAmount(token0, 100000),
@@ -1381,7 +1391,7 @@ describe('MixedRouteTrade', () => {
   })
 
   describe('multihop v2 + v3 + v4', () => {
-    it('can be constructed with an eth output from a v4 pool', async () => {
+    it('can be constructed with a weth output from a v4 pool', async () => {
       const trade = await MixedRouteTrade.fromRoute(
         new MixedRouteSDK([pool_v3_0_1, pool_v4_0_weth], token1, WETH9[1]),
         CurrencyAmount.fromRawAmount(token1, JSBI.BigInt(100)),
@@ -1389,6 +1399,56 @@ describe('MixedRouteTrade', () => {
       )
       expect(trade.inputAmount.currency).toEqual(token1)
       expect(trade.outputAmount.currency).toEqual(WETH9[1])
+    })
+
+    it('can be constructed with an eth output from a v4 pool', async () => {
+      const trade = await MixedRouteTrade.fromRoute(
+        new MixedRouteSDK([pool_v3_0_1, pool_v4_0_eth], token1, ETHER),
+        CurrencyAmount.fromRawAmount(token1, JSBI.BigInt(100)),
+        TradeType.EXACT_INPUT
+      )
+      expect(trade.inputAmount.currency).toEqual(token1)
+      expect(trade.outputAmount.currency).toEqual(ETHER)
+    })
+
+    it('can be constructed with an eth output from a v4 weth pool', async () => {
+      const trade = await MixedRouteTrade.fromRoute(
+        new MixedRouteSDK([pool_v3_0_1, pool_v4_0_weth], token1, ETHER),
+        CurrencyAmount.fromRawAmount(token1, JSBI.BigInt(100)),
+        TradeType.EXACT_INPUT
+      )
+      expect(trade.inputAmount.currency).toEqual(token1)
+      expect(trade.outputAmount.currency).toEqual(ETHER)
+    })
+
+    it('can be constructed with an intermediate conversion WETH->ETH when trading to v4 pool', async () => {
+      const trade = await MixedRouteTrade.fromRoute(
+        new MixedRouteSDK([pool_v3_weth_0, pool_v4_0_eth], token0, ETHER),
+        CurrencyAmount.fromRawAmount(token0, JSBI.BigInt(100)),
+        TradeType.EXACT_INPUT
+      )
+      expect(trade.inputAmount.currency).toEqual(token0)
+      expect(trade.outputAmount.currency).toEqual(ETHER)
+    })
+
+    it('can be constructed with an intermediate conversion ETH->WETH when trading from a v4 pool', async () => {
+      const trade = await MixedRouteTrade.fromRoute(
+        new MixedRouteSDK([pool_v4_0_eth, pool_v3_weth_0], token0, WETH9[1]),
+        CurrencyAmount.fromRawAmount(token0, JSBI.BigInt(100)),
+        TradeType.EXACT_INPUT
+      )
+      expect(trade.inputAmount.currency).toEqual(token0)
+      expect(trade.outputAmount.currency).toEqual(WETH9[1])
+    })
+
+    it('can be constructed with an intermediate conversion ETH->WETH when trading from a v4 pool with ETH output', async () => {
+      const trade = await MixedRouteTrade.fromRoute(
+        new MixedRouteSDK([pool_v4_0_eth, pool_v3_weth_0], token0, ETHER),
+        CurrencyAmount.fromRawAmount(token0, JSBI.BigInt(100)),
+        TradeType.EXACT_INPUT
+      )
+      expect(trade.inputAmount.currency).toEqual(token0)
+      expect(trade.outputAmount.currency).toEqual(ETHER)
     })
   })
 })

--- a/sdks/router-sdk/src/utils/getOutputAmount.ts
+++ b/sdks/router-sdk/src/utils/getOutputAmount.ts
@@ -12,9 +12,17 @@ export async function getOutputAmount(
   if (pool instanceof V4Pool) {
     if (pool.involvesCurrency(amountIn.currency)) {
       return await pool.getOutputAmount(amountIn)
-    } else if (pool.involvesCurrency(amountIn.currency.wrapped)) {
+    }
+    if (pool.involvesCurrency(amountIn.currency.wrapped)) {
       return await pool.getOutputAmount(amountIn.wrapped)
     }
+    if (pool.token0.wrapped.equals(amountIn.currency)) {
+      return await pool.getOutputAmount(CurrencyAmount.fromRawAmount(pool.token0, amountIn.quotient))
+    }
+    if (pool.token1.wrapped.equals(amountIn.currency)) {
+      return await pool.getOutputAmount(CurrencyAmount.fromRawAmount(pool.token1, amountIn.quotient))
+    }
   }
+
   return await pool.getOutputAmount(amountIn.wrapped)
 }

--- a/sdks/router-sdk/src/utils/isValidTokenPath.ts
+++ b/sdks/router-sdk/src/utils/isValidTokenPath.ts
@@ -1,0 +1,25 @@
+import { Currency, Token } from '@uniswap/sdk-core'
+import { Pool as V4Pool } from '@uniswap/v4-sdk'
+import { Pair } from '@uniswap/v2-sdk'
+import { Pool as V3Pool } from '@uniswap/v3-sdk'
+
+type TPool = Pair | V3Pool | V4Pool
+
+export function isValidTokenPath(prevPool: TPool, currentPool: TPool, inputToken: Currency): boolean {
+  if (currentPool.involvesToken(inputToken as Token)) return true
+
+  // throw if both v4 pools, native/wrapped tokens not interchangeable in v4
+  if (prevPool instanceof V4Pool && currentPool instanceof V4Pool) return false
+
+  // v2/v3 --> v4 valid if v2/v3 output is the wrapped version of the v4 pool native currency
+  if (currentPool instanceof V4Pool){
+    if (currentPool.token0.wrapped.equals(inputToken) || currentPool.token1.wrapped.equals(inputToken)) return true
+  }
+
+  // v4 --> v2/v3 valid if v4 output is the native version of the v2/v3 wrapped token
+  if (prevPool instanceof V4Pool) {
+    if (currentPool.involvesToken(inputToken.wrapped)) return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## Description

Valid Routes:
- `v2/v3 --> v4 WETH unwraps to ETH`
- `v4 --> `v2/v3 ETH wraps to WETH`
Invalid Routes:
- `v4 --> v4 WETH unwraps to ETH`
- `v4 --> v4 ETH wraps to WETH`
v4 routes must trade through WETH/ETH pools to make this conversion

## How Has This Been Tested?

unit tests

## Are there any breaking changes?

I don't think so

## (Optional) Feedback Focus

make sure all conditions are met.

## (Optional) Follow Ups

