### PR TITLE
chore(infra): Adds secret scanning

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,43 @@
+name: Trufflehog
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  TruffleHog:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog OSS
+        id: trufflehog
+        uses: trufflesecurity/trufflehog@b0fd951652a50ffb1911073f0bfb6a8ade7afc37
+        continue-on-error: true
+        with:
+          path: ./
+          base: "${{ github.event.repository.default_branch }}"
+          head: HEAD
+          extra_args: --debug --only-verified 
+
+      - name: Scan Results Status
+        if: steps.trufflehog.outcome == 'failure'
+        run: exit 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,14 @@
+if command -v git-secrets &> /dev/null
+then # only run if git-secrets is installed
+  # Initialise git-secrets configuration
+  git-secrets --register-aws > /dev/null
+  
+  echo "Running git-secrets..."
+  # Scans all files that are about to be committed.
+  git-secrets --pre_commit_hook -- "$@"
+fi
+
+if command -v trufflehog &> /dev/null
+then # only run if trufflehog is installed
+  trufflehog git file://. --since-commit HEAD --only-verified --fail
+fi

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A repository for many Uniswap SDK's. All SDK's can be found in `sdk/` and have m
 # Clone
 git clone --recurse-submodules https://github.com/Uniswap/sdks.git
 # Install
-yarn
+yarn g:install
 # Build
 yarn g:build
 # Typecheck

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
   "packageManager": "yarn@3.2.3",
   "private": true,
   "scripts": {
+    "g:install": "yarn install && husky",
     "g:check:deps:mismatch": "manypkg check",
     "g:build": "turbo run build",
     "g:lint": "turbo run lint",
     "g:release": "turbo run release --concurrency=1 --continue",
     "g:test": "turbo run test",
     "g:typecheck": "turbo run typecheck",
-    "sdk": "yarn workspace"
+    "sdk": "yarn workspace",
   },
   "workspaces": [
     "sdks/*",


### PR DESCRIPTION
## PR Scope

Adds secret scanning

## Description
Adds secret scanning on precommit hooks and at the PR (just in case you add --no-verify) 

## How Has This Been Tested?

Manually

## Are there any breaking changes?

No

## (Optional) Feedback Focus

Make sure that the install is still easy for users on the read me. I reran it just to be safe, but it's a case of "it works on my machine" 
