### PR TITLE
Fix sig verification

### DIFF
--- a/sdks/uniswapx-sdk/src/order/V3DutchOrder.ts
+++ b/sdks/uniswapx-sdk/src/order/V3DutchOrder.ts
@@ -547,7 +547,7 @@ export class CosignedV3DutchOrder extends UnsignedV3DutchOrder {
     recoverCosigner(): string {
         const messageHash = this.cosignatureHash(this.info.cosignerData);
         const signature = this.info.cosignature;
-        return ethers.utils.recoverAddress(messageHash, signature);
+        return ethers.utils.verifyMessage(messageHash, signature);
     }
 
     resolve(options: V3OrderResolutionOptions): ResolvedUniswapXOrder {


### PR DESCRIPTION
`recoverAddress()` will hash the message first before recoverying. Since `signMessage()` does the same (hash first) then they will produce the same address.