### PR TITLE
feat(v3/v4-sdk): add Permit building

### DIFF
--- a/sdks/v3-sdk/src/nonfungiblePositionManager.test.ts
+++ b/sdks/v3-sdk/src/nonfungiblePositionManager.test.ts
@@ -1,4 +1,5 @@
 import { Percent, Token, CurrencyAmount, WETH9, Ether } from '@uniswap/sdk-core'
+import { ethers } from 'ethers';
 import { FeeAmount, TICK_SPACINGS } from './constants'
 import { Pool } from './entities/pool'
 import { Position } from './entities/position'
@@ -377,4 +378,38 @@ describe('NonfungiblePositionManager', () => {
       expect(value).toEqual('0x00')
     })
   })
+
+  describe('#getPermitData', () => {
+    it('succeeds', () => {
+      const mockPositionManager = '0x0000000000000000000000000000000000000001';
+      const permit = {
+        spender: '0x0000000000000000000000000000000000000002',
+        tokenId: 1,
+        deadline: 123,
+        nonce: 1,
+      };
+      const { domain, types, values } = NonfungiblePositionManager.getPermitData(permit, mockPositionManager, 1);
+      expect(domain).toEqual({
+        name: 'Uniswap V3 Positions NFT-V1',
+        chainId: 1,
+        verifyingContract: mockPositionManager,
+      });
+      expect(types).toEqual({
+        Permit: [
+          { name: 'spender', type: 'address' },
+          { name: 'tokenId', type: 'uint256' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'deadline', type: 'uint256' },
+        ],
+      });
+      expect(values).toEqual(permit);
+      // get typehash
+      const encodedType = ethers.utils._TypedDataEncoder.from(types).encodeType('Permit');
+
+      // Compute the type hash by hashing the encoded type
+      const typeHash = ethers.utils.id(encodedType);
+      // ref https://github.com/Uniswap/v3-periphery/blob/main/contracts/base/ERC721Permit.sol
+      expect(typeHash).toEqual('0x49ecf333e5b8c95c40fdafc95c1ad136e8914a8fb55e9dc8bb01eaa83a2df9ad');
+    });
+  });
 })

--- a/sdks/v3-sdk/src/nonfungiblePositionManager.test.ts
+++ b/sdks/v3-sdk/src/nonfungiblePositionManager.test.ts
@@ -1,5 +1,5 @@
 import { Percent, Token, CurrencyAmount, WETH9, Ether } from '@uniswap/sdk-core'
-import { ethers } from 'ethers';
+import { ethers } from 'ethers'
 import { FeeAmount, TICK_SPACINGS } from './constants'
 import { Pool } from './entities/pool'
 import { Position } from './entities/position'
@@ -381,19 +381,19 @@ describe('NonfungiblePositionManager', () => {
 
   describe('#getPermitData', () => {
     it('succeeds', () => {
-      const mockPositionManager = '0x0000000000000000000000000000000000000001';
+      const mockPositionManager = '0x0000000000000000000000000000000000000001'
       const permit = {
         spender: '0x0000000000000000000000000000000000000002',
         tokenId: 1,
         deadline: 123,
         nonce: 1,
-      };
-      const { domain, types, values } = NonfungiblePositionManager.getPermitData(permit, mockPositionManager, 1);
+      }
+      const { domain, types, values } = NonfungiblePositionManager.getPermitData(permit, mockPositionManager, 1)
       expect(domain).toEqual({
         name: 'Uniswap V3 Positions NFT-V1',
         chainId: 1,
         verifyingContract: mockPositionManager,
-      });
+      })
       expect(types).toEqual({
         Permit: [
           { name: 'spender', type: 'address' },
@@ -401,15 +401,15 @@ describe('NonfungiblePositionManager', () => {
           { name: 'nonce', type: 'uint256' },
           { name: 'deadline', type: 'uint256' },
         ],
-      });
-      expect(values).toEqual(permit);
+      })
+      expect(values).toEqual(permit)
       // get typehash
-      const encodedType = ethers.utils._TypedDataEncoder.from(types).encodeType('Permit');
+      const encodedType = ethers.utils._TypedDataEncoder.from(types).encodeType('Permit')
 
       // Compute the type hash by hashing the encoded type
-      const typeHash = ethers.utils.id(encodedType);
+      const typeHash = ethers.utils.id(encodedType)
       // ref https://github.com/Uniswap/v3-periphery/blob/main/contracts/base/ERC721Permit.sol
-      expect(typeHash).toEqual('0x49ecf333e5b8c95c40fdafc95c1ad136e8914a8fb55e9dc8bb01eaa83a2df9ad');
-    });
-  });
+      expect(typeHash).toEqual('0x49ecf333e5b8c95c40fdafc95c1ad136e8914a8fb55e9dc8bb01eaa83a2df9ad')
+    })
+  })
 })

--- a/sdks/v3-sdk/src/nonfungiblePositionManager.ts
+++ b/sdks/v3-sdk/src/nonfungiblePositionManager.ts
@@ -13,6 +13,7 @@ import { Position } from './entities/position'
 import { ONE, ZERO } from './internalConstants'
 import { MethodParameters, toHex } from './utils/calldata'
 import { Interface } from '@ethersproject/abi'
+import { TypedDataDomain, TypedDataField } from '@ethersproject/abstract-signer';
 import INonfungiblePositionManager from '@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json'
 import { PermitOptions, SelfPermit } from './selfPermit'
 import { ADDRESS_ZERO } from './constants'
@@ -122,6 +123,28 @@ export interface CollectOptions {
    * The account that should receive the tokens.
    */
   recipient: string
+}
+
+const NFT_PERMIT_TYPES = {
+  Permit: [
+    { name: 'spender', type: 'address' },
+    { name: 'tokenId', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ],
+};
+
+export interface NFTPermitValues {
+  spender: string
+  tokenId: BigintIsh
+  deadline: BigintIsh
+  nonce: BigintIsh
+}
+
+export interface NFTPermitData {
+  domain: TypedDataDomain;
+  types: Record<string, TypedDataField[]>;
+  values: NFTPermitValues;
 }
 
 export interface NFTPermitOptions {
@@ -433,6 +456,23 @@ export abstract class NonfungiblePositionManager {
     return {
       calldata: calldata,
       value: toHex(0),
+    }
+  }
+
+  // Prepare the params for an EIP712 signTypedData request
+  public static getPermitData(
+    permit: NFTPermitValues,
+    positionManagerAddress: string,
+    chainId: number,
+  ): NFTPermitData {
+    return {
+      domain: {
+        name: 'Uniswap V3 Positions NFT-V1',
+        chainId,
+        verifyingContract: positionManagerAddress,
+      },
+      types: NFT_PERMIT_TYPES,
+      values: permit,
     }
   }
 }

--- a/sdks/v3-sdk/src/nonfungiblePositionManager.ts
+++ b/sdks/v3-sdk/src/nonfungiblePositionManager.ts
@@ -13,7 +13,7 @@ import { Position } from './entities/position'
 import { ONE, ZERO } from './internalConstants'
 import { MethodParameters, toHex } from './utils/calldata'
 import { Interface } from '@ethersproject/abi'
-import { TypedDataDomain, TypedDataField } from '@ethersproject/abstract-signer';
+import { TypedDataDomain, TypedDataField } from '@ethersproject/abstract-signer'
 import INonfungiblePositionManager from '@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json'
 import { PermitOptions, SelfPermit } from './selfPermit'
 import { ADDRESS_ZERO } from './constants'
@@ -132,7 +132,7 @@ const NFT_PERMIT_TYPES = {
     { name: 'nonce', type: 'uint256' },
     { name: 'deadline', type: 'uint256' },
   ],
-};
+}
 
 export interface NFTPermitValues {
   spender: string
@@ -142,9 +142,9 @@ export interface NFTPermitValues {
 }
 
 export interface NFTPermitData {
-  domain: TypedDataDomain;
-  types: Record<string, TypedDataField[]>;
-  values: NFTPermitValues;
+  domain: TypedDataDomain
+  types: Record<string, TypedDataField[]>
+  values: NFTPermitValues
 }
 
 export interface NFTPermitOptions {
@@ -460,11 +460,7 @@ export abstract class NonfungiblePositionManager {
   }
 
   // Prepare the params for an EIP712 signTypedData request
-  public static getPermitData(
-    permit: NFTPermitValues,
-    positionManagerAddress: string,
-    chainId: number,
-  ): NFTPermitData {
+  public static getPermitData(permit: NFTPermitValues, positionManagerAddress: string, chainId: number): NFTPermitData {
     return {
       domain: {
         name: 'Uniswap V3 Positions NFT-V1',

--- a/sdks/v4-sdk/src/PositionManager.test.ts
+++ b/sdks/v4-sdk/src/PositionManager.test.ts
@@ -1,5 +1,5 @@
 import { Ether, Percent, Token } from '@uniswap/sdk-core'
-import { ethers } from 'ethers';
+import { ethers } from 'ethers'
 import {
   EMPTY_BYTES,
   EMPTY_HOOK,
@@ -517,13 +517,13 @@ describe('PositionManager', () => {
         tokenId: 1,
         deadline: 123,
         nonce: 1,
-      };
-      const { domain, types, values } = V4PositionManager.getPermitData(permit, mockOwner, 1);
+      }
+      const { domain, types, values } = V4PositionManager.getPermitData(permit, mockOwner, 1)
       expect(domain).toEqual({
         name: 'Uniswap V4 Positions NFT',
         chainId: 1,
         verifyingContract: mockOwner,
-      });
+      })
       expect(types).toEqual({
         Permit: [
           { name: 'spender', type: 'address' },
@@ -531,15 +531,15 @@ describe('PositionManager', () => {
           { name: 'nonce', type: 'uint256' },
           { name: 'deadline', type: 'uint256' },
         ],
-      });
-      expect(values).toEqual(permit);
+      })
+      expect(values).toEqual(permit)
       // get typehash
-      const encodedType = ethers.utils._TypedDataEncoder.from(types).encodeType('Permit');
+      const encodedType = ethers.utils._TypedDataEncoder.from(types).encodeType('Permit')
 
       // Compute the type hash by hashing the encoded type
-      const typeHash = ethers.utils.id(encodedType);
+      const typeHash = ethers.utils.id(encodedType)
       // ref https://github.com/Uniswap/v3-periphery/blob/main/contracts/base/ERC721Permit.sol
-      expect(typeHash).toEqual('0x49ecf333e5b8c95c40fdafc95c1ad136e8914a8fb55e9dc8bb01eaa83a2df9ad');
-    });
-  });
+      expect(typeHash).toEqual('0x49ecf333e5b8c95c40fdafc95c1ad136e8914a8fb55e9dc8bb01eaa83a2df9ad')
+    })
+  })
 })

--- a/sdks/v4-sdk/src/PositionManager.test.ts
+++ b/sdks/v4-sdk/src/PositionManager.test.ts
@@ -1,4 +1,5 @@
 import { Ether, Percent, Token } from '@uniswap/sdk-core'
+import { ethers } from 'ethers';
 import {
   EMPTY_BYTES,
   EMPTY_HOOK,
@@ -508,4 +509,37 @@ describe('PositionManager', () => {
       expect(value).toEqual('0x00')
     })
   })
+
+  describe('#getPermitData', () => {
+    it('succeeds', () => {
+      const permit = {
+        spender: mockSpender,
+        tokenId: 1,
+        deadline: 123,
+        nonce: 1,
+      };
+      const { domain, types, values } = V4PositionManager.getPermitData(permit, mockOwner, 1);
+      expect(domain).toEqual({
+        name: 'Uniswap V4 Positions NFT',
+        chainId: 1,
+        verifyingContract: mockOwner,
+      });
+      expect(types).toEqual({
+        Permit: [
+          { name: 'spender', type: 'address' },
+          { name: 'tokenId', type: 'uint256' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'deadline', type: 'uint256' },
+        ],
+      });
+      expect(values).toEqual(permit);
+      // get typehash
+      const encodedType = ethers.utils._TypedDataEncoder.from(types).encodeType('Permit');
+
+      // Compute the type hash by hashing the encoded type
+      const typeHash = ethers.utils.id(encodedType);
+      // ref https://github.com/Uniswap/v3-periphery/blob/main/contracts/base/ERC721Permit.sol
+      expect(typeHash).toEqual('0x49ecf333e5b8c95c40fdafc95c1ad136e8914a8fb55e9dc8bb01eaa83a2df9ad');
+    });
+  });
 })

--- a/sdks/v4-sdk/src/PositionManager.ts
+++ b/sdks/v4-sdk/src/PositionManager.ts
@@ -1,4 +1,5 @@
 import { BigintIsh, Percent, validateAndParseAddress, Currency, NativeCurrency } from '@uniswap/sdk-core'
+import { TypedDataDomain, TypedDataField } from '@ethersproject/abstract-signer';
 import JSBI from 'jsbi'
 import { Position } from './entities/position'
 import { MethodParameters, toHex } from './utils/calldata'
@@ -149,12 +150,30 @@ export interface BatchPermitOptions {
   signature: string
 }
 
-export interface NFTPermitOptions {
+const NFT_PERMIT_TYPES = {
+  Permit: [
+    { name: 'spender', type: 'address' },
+    { name: 'tokenId', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ],
+};
+
+export interface NFTPermitValues {
   spender: string
   tokenId: BigintIsh
   deadline: BigintIsh
   nonce: BigintIsh
+}
+
+export interface NFTPermitOptions extends NFTPermitValues {
   signature: string
+}
+
+export interface NFTPermitData {
+  domain: TypedDataDomain;
+  types: Record<string, TypedDataField[]>;
+  values: NFTPermitValues;
 }
 
 export type MintOptions = CommonOptions & CommonAddLiquidityOptions & MintSpecificOptions
@@ -416,5 +435,22 @@ export abstract class V4PositionManager {
       nonce,
       signature,
     ])
+  }
+
+  // Prepare the params for an EIP712 signTypedData request
+  public static getPermitData(
+    permit: NFTPermitValues,
+    positionManagerAddress: string,
+    chainId: number,
+  ): NFTPermitData {
+    return {
+      domain: {
+        name: 'Uniswap V4 Positions NFT',
+        chainId,
+        verifyingContract: positionManagerAddress,
+      },
+      types: NFT_PERMIT_TYPES,
+      values: permit,
+    }
   }
 }

--- a/sdks/v4-sdk/src/PositionManager.ts
+++ b/sdks/v4-sdk/src/PositionManager.ts
@@ -1,5 +1,5 @@
 import { BigintIsh, Percent, validateAndParseAddress, Currency, NativeCurrency } from '@uniswap/sdk-core'
-import { TypedDataDomain, TypedDataField } from '@ethersproject/abstract-signer';
+import { TypedDataDomain, TypedDataField } from '@ethersproject/abstract-signer'
 import JSBI from 'jsbi'
 import { Position } from './entities/position'
 import { MethodParameters, toHex } from './utils/calldata'
@@ -157,7 +157,7 @@ const NFT_PERMIT_TYPES = {
     { name: 'nonce', type: 'uint256' },
     { name: 'deadline', type: 'uint256' },
   ],
-};
+}
 
 export interface NFTPermitValues {
   spender: string
@@ -171,9 +171,9 @@ export interface NFTPermitOptions extends NFTPermitValues {
 }
 
 export interface NFTPermitData {
-  domain: TypedDataDomain;
-  types: Record<string, TypedDataField[]>;
-  values: NFTPermitValues;
+  domain: TypedDataDomain
+  types: Record<string, TypedDataField[]>
+  values: NFTPermitValues
 }
 
 export type MintOptions = CommonOptions & CommonAddLiquidityOptions & MintSpecificOptions
@@ -438,11 +438,7 @@ export abstract class V4PositionManager {
   }
 
   // Prepare the params for an EIP712 signTypedData request
-  public static getPermitData(
-    permit: NFTPermitValues,
-    positionManagerAddress: string,
-    chainId: number,
-  ): NFTPermitData {
+  public static getPermitData(permit: NFTPermitValues, positionManagerAddress: string, chainId: number): NFTPermitData {
     return {
       domain: {
         name: 'Uniswap V4 Positions NFT',


### PR DESCRIPTION
This commit adds helper functions for building the domains, types,
values of permits for v3 and v4 NFTs

## PR Scope

Please title your PR according to the following types and scopes following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/):

- `fix(SDK name):` will trigger a patch version
- `chore(<type>):` will not trigger any release and should be used for internal repo changes
- `<type>(public):` will trigger a patch version for non-code changes (e.g. README changes)
- `feat(SDK name):` will trigger a minor version
- `feat(breaking):` will trigger a major version for a breaking change

## Description

_[Summary of the change, motivation, and context]_

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

_[e.g. Type definitions, API definitions]_

If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_
