### PR TITLE
feat(v2-sdk): bump sdk-core to have v2-sdk factory address on worldchain

### DIFF
--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ethersproject/address": "^5.0.2",
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^5.3.1",
+    "@uniswap/sdk-core": "^5.6.0",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4656,6 +4656,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uniswap/sdk-core@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "@uniswap/sdk-core@npm:5.6.0"
+  dependencies:
+    "@ethersproject/address": ^5.0.2
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/keccak256": 5.7.0
+    "@ethersproject/strings": 5.7.0
+    big.js: ^5.2.2
+    decimal.js-light: ^2.5.0
+    jsbi: ^3.1.4
+    tiny-invariant: ^1.1.0
+    toformat: ^2.0.0
+  checksum: 2fabe33e94e70a1fb3d194ef3e622920cd0eed2a23e68a0cf0c3535a8589a0175b4c6a8c7aed55a28d16539ff3ea9058ada5a98200f82728179f3b8445856665
+  languageName: node
+  linkType: hard
+
 "@uniswap/sdk-core@workspace:sdks/sdk-core":
   version: 0.0.0-use.local
   resolution: "@uniswap/sdk-core@workspace:sdks/sdk-core"
@@ -4792,7 +4809,7 @@ __metadata:
     "@ethersproject/solidity": ^5.0.9
     "@types/big.js": ^4.0.5
     "@types/jest": ^24.0.25
-    "@uniswap/sdk-core": ^5.3.1
+    "@uniswap/sdk-core": ^5.6.0
     "@uniswap/v2-core": ^1.0.1
     eslint-config-react-app: 7.0.1
     tiny-invariant: ^1.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4639,24 +4639,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "@uniswap/sdk-core@npm:5.3.1"
-  dependencies:
-    "@ethersproject/address": ^5.0.2
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/keccak256": 5.7.0
-    "@ethersproject/strings": 5.7.0
-    big.js: ^5.2.2
-    decimal.js-light: ^2.5.0
-    jsbi: ^3.1.4
-    tiny-invariant: ^1.1.0
-    toformat: ^2.0.0
-  checksum: fcf33b2dc07f740070a79468f9c7d0badd668a8126b512c5cfa71d5f7a406fe0d25b5d6994745b8c2f112a0f416c76cd5cc7e1b3198039813c3a09539f6fe345
-  languageName: node
-  linkType: hard
-
-"@uniswap/sdk-core@npm:^5.6.0":
+"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.6.0":
   version: 5.6.0
   resolution: "@uniswap/sdk-core@npm:5.6.0"
   dependencies:


### PR DESCRIPTION
## Description

Bump sdk-core in v2-sdk. This is needed because v2-sdk [FACTORY_ADDRESS_MAP](https://github.com/Uniswap/sdks/blob/main/sdks/v2-sdk/src/constants.ts#L9) uses V2_FACTORY_ADDRESSES from sdk-core

## How Has This Been Tested?

Will test in routing

## Are there any breaking changes?

No

## (Optional) Feedback Focus

## (Optional) Follow Ups
