### PR TITLE
feat(v3-sdk): bump sdk-core to have worldchain chain id

### DIFF
--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^5.3.1",
+    "@uniswap/sdk-core": "^5.6.0",
     "@uniswap/swap-router-contracts": "^1.3.0",
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-staker": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4639,9 +4639,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "@uniswap/sdk-core@npm:5.3.1"
+"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "@uniswap/sdk-core@npm:5.6.0"
   dependencies:
     "@ethersproject/address": ^5.0.2
     "@ethersproject/bytes": ^5.7.0
@@ -4652,7 +4652,7 @@ __metadata:
     jsbi: ^3.1.4
     tiny-invariant: ^1.1.0
     toformat: ^2.0.0
-  checksum: fcf33b2dc07f740070a79468f9c7d0badd668a8126b512c5cfa71d5f7a406fe0d25b5d6994745b8c2f112a0f416c76cd5cc7e1b3198039813c3a09539f6fe345
+  checksum: 2fabe33e94e70a1fb3d194ef3e622920cd0eed2a23e68a0cf0c3535a8589a0175b4c6a8c7aed55a28d16539ff3ea9058ada5a98200f82728179f3b8445856665
   languageName: node
   linkType: hard
 
@@ -4867,7 +4867,7 @@ __metadata:
     "@ethersproject/abi": ^5.5.0
     "@ethersproject/solidity": ^5.0.9
     "@types/jest": ^24.0.25
-    "@uniswap/sdk-core": ^5.3.1
+    "@uniswap/sdk-core": ^5.6.0
     "@uniswap/swap-router-contracts": ^1.3.0
     "@uniswap/v3-core": 1.0.0
     "@uniswap/v3-periphery": ^1.1.1


### PR DESCRIPTION
## Description

Bump sdk-core in v3-sdk. v3-sdk uses ChainId enum from sdk-core https://github.com/search?q=repo%3AUniswap%2Fsdks+sdk-core+path%3A%2F%5Esdks%5C%2Fv3-sdk%5C%2F%2F&type=code, so v3-sdk needs worldchain chain id

## How Has This Been Tested?

Will test in routing.

## Are there any breaking changes?

No

## (Optional) Feedback Focus

## (Optional) Follow Ups
