### PR TITLE
feat(ur-sdk): allow commands override

### DIFF
--- a/sdks/universal-router-sdk/src/index.ts
+++ b/sdks/universal-router-sdk/src/index.ts
@@ -1,7 +1,15 @@
 export { SwapRouter, MigrateV3ToV4Options } from './swapRouter'
 export * from './entities'
 export * from './utils/routerTradeAdapter'
-export { RoutePlanner, CommandType } from './utils/routerCommands'
+export {
+  RoutePlanner,
+  CommandType,
+  COMMAND_DEFINITION,
+  CommandDefinition,
+  Parser,
+  Subparser,
+  ParamType,
+} from './utils/routerCommands'
 export {
   UNIVERSAL_ROUTER_CREATION_BLOCK,
   UNIVERSAL_ROUTER_ADDRESS,

--- a/sdks/universal-router-sdk/src/index.ts
+++ b/sdks/universal-router-sdk/src/index.ts
@@ -9,4 +9,10 @@ export {
   WETH_ADDRESS,
   UniversalRouterVersion,
 } from './utils/constants'
-export { CommandParser, UniversalRouterCommand, UniversalRouterCall, Param } from './utils/commandParser'
+export {
+  CommandParser,
+  UniversalRouterCommand,
+  UniversalRouterCall,
+  Param,
+  CommandsDefinition,
+} from './utils/commandParser'


### PR DESCRIPTION
This commit refactors the parser to allow injection of arbitrary
commands definitions. This enables supporting old UR command sets

## PR Scope

Please title your PR according to the following types and scopes following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/):

- `fix(SDK name):` will trigger a patch version
- `chore(<type>):` will not trigger any release and should be used for internal repo changes
- `<type>(public):` will trigger a patch version for non-code changes (e.g. README changes)
- `feat(SDK name):` will trigger a minor version
- `feat(breaking):` will trigger a major version for a breaking change

## Description

_[Summary of the change, motivation, and context]_

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

_[e.g. Type definitions, API definitions]_

If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_
