### PR TITLE
fix(sdk-core): add v4Quoter, stateView, viewQuoterV3, add sepolia weth9

### DIFF
--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -16,6 +16,8 @@ type ChainAddresses = {
   // v4
   v4PoolManagerAddress?: string
   v4PositionManagerAddress?: string
+  v4StateView?: string
+  v4QuoterAddress?: string
 }
 
 const DEFAULT_NETWORKS = [ChainId.MAINNET, ChainId.GOERLI, ChainId.SEPOLIA]
@@ -171,11 +173,12 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   nonfungiblePositionManagerAddress: '0x1238536071E1c677A632429e3655c799b22cDA52',
   tickLensAddress: '0xd7f33bcdb21b359c8ee6f0251d30e94832baad07',
   swapRouter02Address: '0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E',
-  // TODO: ROUTE-277 - update deploy address once after quoter refactoring.
-  mixedRouteQuoterV2Address: '0xa8b0be287acB850952DE4287b84B7222cc654C09',
+  mixedRouteQuoterV2Address: '0x4745f77b56a0e2294426e3936dc4fab68d9543cd',
 
   v4PoolManagerAddress: '0xE8E23e97Fa135823143d6b9Cba9c699040D51F70',
   v4PositionManagerAddress: '0x0048d1C09771Bb87b6A44e1294769E1DFd698584',
+  v4StateView: '0x6Bb7157fb50e3Ae4983Ccdc62Fb8173c03c6b0a7',
+  v4QuoterAddress: '0x9336CF25dDad216FD480A5422CBEa7b3BC5bDda8'
 }
 
 // Avalanche v3 addresses
@@ -278,6 +281,11 @@ const ASTROCHAIN_SEPOLIA_ADDRESSES: ChainAddresses = {
   nonfungiblePositionManagerAddress: '0xB7F724d6dDDFd008eFf5cc2834edDE5F9eF0d075',
   tickLensAddress: '0x5f739c790a48E97eec0efb81bab5D152c0A0ecA0',
   swapRouter02Address: '0xd1AAE39293221B77B0C71fBD6dCb7Ea29Bb5B166',
+
+  v4PoolManagerAddress: '0x38EB8B22Df3Ae7fb21e92881151B365Df14ba967',
+  v4PositionManagerAddress: '0x05deD3F8a8e84700d68A4D81cd6780c982dB13F9',
+  v4StateView: '0xad328439DCa7ce857662afA4584A3d571bbDDC75',
+  v4QuoterAddress: '0x2cfa87651D3AB05Bc59E325E5eaC8495CF34cE55'
 }
 
 export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses> = {

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -178,7 +178,7 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   v4PoolManagerAddress: '0xE8E23e97Fa135823143d6b9Cba9c699040D51F70',
   v4PositionManagerAddress: '0x0048d1C09771Bb87b6A44e1294769E1DFd698584',
   v4StateView: '0x6Bb7157fb50e3Ae4983Ccdc62Fb8173c03c6b0a7',
-  v4QuoterAddress: '0x9336CF25dDad216FD480A5422CBEa7b3BC5bDda8'
+  v4QuoterAddress: '0x9336CF25dDad216FD480A5422CBEa7b3BC5bDda8',
 }
 
 // Avalanche v3 addresses
@@ -285,7 +285,7 @@ const ASTROCHAIN_SEPOLIA_ADDRESSES: ChainAddresses = {
   v4PoolManagerAddress: '0x38EB8B22Df3Ae7fb21e92881151B365Df14ba967',
   v4PositionManagerAddress: '0x05deD3F8a8e84700d68A4D81cd6780c982dB13F9',
   v4StateView: '0xad328439DCa7ce857662afA4584A3d571bbDDC75',
-  v4QuoterAddress: '0x2cfa87651D3AB05Bc59E325E5eaC8495CF34cE55'
+  v4QuoterAddress: '0x2cfa87651D3AB05Bc59E325E5eaC8495CF34cE55',
 }
 
 export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses> = {

--- a/sdks/sdk-core/src/entities/weth9.ts
+++ b/sdks/sdk-core/src/entities/weth9.ts
@@ -5,6 +5,7 @@ import { Token } from './token'
  */
 export const WETH9: { [chainId: number]: Token } = {
   1: new Token(1, '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', 18, 'WETH', 'Wrapped Ether'),
+  11155111: new Token(11155111, '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14', 18, 'WETH', 'Wrapped Ether'),
   3: new Token(3, '0xc778417E063141139Fce010982780140Aa0cD5Ab', 18, 'WETH', 'Wrapped Ether'),
   4: new Token(4, '0xc778417E063141139Fce010982780140Aa0cD5Ab', 18, 'WETH', 'Wrapped Ether'),
   5: new Token(5, '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6', 18, 'WETH', 'Wrapped Ether'),


### PR DESCRIPTION
_[Summary of the change, motivation, and context]_

we have deployed v4 to sepolia and astrochain sepolia. for v4, we are missing state view and quoter addresses, hence adding in sepolia. astrochain sepolia was more recently deployed with v4, so adding there as well.

sepolia 11155111 weth9 is good to be added, although based on the chat with @zhongeric , it should only be used in [SwapRouter02.sol](https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/SwapRouter02.sol), which is deprecated in favor in Universal Router. in Uniswap frontend and Uniswap backend, we do not submit calldata to SwapRouter02.sol, only to Universal Router

_[e.g. Manually, E2E tests, unit tests, Storybook]_

No

_[e.g. Type definitions, API definitions]_

No

## (Optional) Feedback Focus

No

## (Optional) Follow Ups

No