### PR TITLE
fix: avoid import conflicts between v4-sdk and ethers-v6

### DIFF
--- a/sdks/v4-sdk/src/PositionManager.test.ts
+++ b/sdks/v4-sdk/src/PositionManager.test.ts
@@ -1,5 +1,5 @@
 import { Ether, Percent, Token } from '@uniswap/sdk-core'
-import { ethers } from 'ethers'
+import { _TypedDataEncoder, id } from '@ethersproject/hash'
 import {
   EMPTY_BYTES,
   EMPTY_HOOK,
@@ -566,10 +566,10 @@ describe('PositionManager', () => {
       })
       expect(values).toEqual(permit)
       // get typehash
-      const encodedType = ethers.utils._TypedDataEncoder.from(types).encodeType('Permit')
+      const encodedType = _TypedDataEncoder.from(types).encodeType('Permit')
 
       // Compute the type hash by hashing the encoded type
-      const typeHash = ethers.utils.id(encodedType)
+      const typeHash = id(encodedType)
       // ref https://github.com/Uniswap/v3-periphery/blob/main/contracts/base/ERC721Permit.sol
       expect(typeHash).toEqual('0x49ecf333e5b8c95c40fdafc95c1ad136e8914a8fb55e9dc8bb01eaa83a2df9ad')
     })

--- a/sdks/v4-sdk/src/entities/pool.ts
+++ b/sdks/v4-sdk/src/entities/pool.ts
@@ -1,4 +1,6 @@
 import invariant from 'tiny-invariant'
+import { defaultAbiCoder } from '@ethersproject/abi'
+import { isAddress } from '@ethersproject/address'
 import { keccak256 } from '@ethersproject/solidity'
 import { BigintIsh, Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
 import {
@@ -10,7 +12,6 @@ import {
   TickListDataProvider,
   TickMath,
 } from '@uniswap/v3-sdk'
-import { defaultAbiCoder, isAddress } from 'ethers/lib/utils'
 import { sortsBefore } from '../utils/sortsBefore'
 import { ADDRESS_ZERO, NEGATIVE_ONE, Q192 } from '../internalConstants'
 import JSBI from 'jsbi'
@@ -119,14 +120,14 @@ export class Pool {
     const nextTickSqrtRatioX96 = TickMath.getSqrtRatioAtTick(tickCurrent + 1)
     invariant(
       JSBI.greaterThanOrEqual(JSBI.BigInt(sqrtRatioX96), tickCurrentSqrtRatioX96) &&
-        JSBI.lessThanOrEqual(JSBI.BigInt(sqrtRatioX96), nextTickSqrtRatioX96),
+      JSBI.lessThanOrEqual(JSBI.BigInt(sqrtRatioX96), nextTickSqrtRatioX96),
       'PRICE_BOUNDS'
     )
 
-    // always create a copy of the list since we want the pool's tick list to be immutable
-    ;[this.currency0, this.currency1] = sortsBefore(currencyA, currencyB)
-      ? [currencyA, currencyB]
-      : [currencyB, currencyA]
+      // always create a copy of the list since we want the pool's tick list to be immutable
+      ;[this.currency0, this.currency1] = sortsBefore(currencyA, currencyB)
+        ? [currencyA, currencyB]
+        : [currencyB, currencyA]
     this.fee = fee
     this.sqrtRatioX96 = JSBI.BigInt(sqrtRatioX96)
     this.tickSpacing = tickSpacing

--- a/sdks/v4-sdk/src/internalConstants.ts
+++ b/sdks/v4-sdk/src/internalConstants.ts
@@ -1,9 +1,9 @@
 import JSBI from 'jsbi'
-import { constants } from 'ethers'
+import { AddressZero } from '@ethersproject/constants'
 import { encodeSqrtRatioX96 } from '@uniswap/v3-sdk'
 
 // constants used internally but not expected to be used externally
-export const ADDRESS_ZERO = constants.AddressZero
+export const ADDRESS_ZERO = AddressZero
 export const NEGATIVE_ONE = JSBI.BigInt(-1)
 export const ZERO = JSBI.BigInt(0)
 export const ONE = JSBI.BigInt(1)

--- a/sdks/v4-sdk/src/utils/v4BaseActionsParser.test.ts
+++ b/sdks/v4-sdk/src/utils/v4BaseActionsParser.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { WETH9 } from '@uniswap/sdk-core'
-import { BigNumber, ethers } from 'ethers'
+import { BigNumber } from '@ethersproject/bignumber'
+import { parseEther } from '@ethersproject/units'
 import { Route } from '../entities/route'
 import { encodeRouteToPath } from './encodeRouteToPath'
 import { V4BaseActionsParser, V4RouterCall } from './v4BaseActionsParser'
@@ -9,7 +10,7 @@ import { USDC_WETH, DAI_USDC, DAI, USDC } from './v4Planner.test'
 
 const addressOne = '0x0000000000000000000000000000000000000001'
 const addressTwo = '0x0000000000000000000000000000000000000002'
-const amount = ethers.utils.parseEther('1')
+const amount = parseEther('1')
 
 describe('Command Parser', () => {
   type ParserTest = {

--- a/sdks/v4-sdk/src/utils/v4BaseActionsParser.ts
+++ b/sdks/v4-sdk/src/utils/v4BaseActionsParser.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers'
+import { defaultAbiCoder } from '@ethersproject/abi'
 import { PoolKey } from '../entities/pool'
 import { PathKey } from './encodeRouteToPath'
 import { Actions, Subparser, V4_BASE_ACTIONS_ABI_DEFINITION } from './v4Planner'
@@ -53,14 +53,14 @@ export type SwapExactOut = {
 // Parses V4Router actions
 export abstract class V4BaseActionsParser {
   public static parseCalldata(calldata: string): V4RouterCall {
-    const [actions, inputs] = ethers.utils.defaultAbiCoder.decode(['bytes', 'bytes[]'], calldata)
+    const [actions, inputs] = defaultAbiCoder.decode(['bytes', 'bytes[]'], calldata)
 
     const actionTypes = V4BaseActionsParser.getActions(actions)
 
     return {
       actions: actionTypes.map((actionType: Actions, i: number) => {
         const abiDef = V4_BASE_ACTIONS_ABI_DEFINITION[actionType]
-        const rawParams = ethers.utils.defaultAbiCoder.decode(
+        const rawParams = defaultAbiCoder.decode(
           abiDef.map((command) => command.type),
           inputs[i]
         )

--- a/sdks/v4-sdk/src/utils/v4Planner.test.ts
+++ b/sdks/v4-sdk/src/utils/v4Planner.test.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers'
+import { BigNumber } from '@ethersproject/bignumber'
 import JSBI from 'jsbi'
 import { CurrencyAmount, Ether, Percent, TradeType, Token, WETH9 } from '@uniswap/sdk-core'
 import { encodeSqrtRatioX96, nearestUsableTick, TickMath } from '@uniswap/v3-sdk'

--- a/sdks/v4-sdk/src/utils/v4Planner.ts
+++ b/sdks/v4-sdk/src/utils/v4Planner.ts
@@ -1,6 +1,6 @@
 import invariant from 'tiny-invariant'
-import { defaultAbiCoder } from 'ethers/lib/utils'
-import { BigNumber } from 'ethers'
+import { defaultAbiCoder } from '@ethersproject/abi'
+import { BigNumber } from '@ethersproject/bignumber'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { Trade } from '../entities/trade'
 import { ADDRESS_ZERO, EMPTY_BYTES } from '../internalConstants'
@@ -194,17 +194,17 @@ export class V4Planner {
     this.addAction(actionType, [
       exactOutput
         ? {
-            currencyOut,
-            path: encodeRouteToPath(trade.route, exactOutput),
-            amountInMaximum: trade.maximumAmountIn(slippageTolerance ?? new Percent(0)).quotient.toString(),
-            amountOut: trade.outputAmount.quotient.toString(),
-          }
+          currencyOut,
+          path: encodeRouteToPath(trade.route, exactOutput),
+          amountInMaximum: trade.maximumAmountIn(slippageTolerance ?? new Percent(0)).quotient.toString(),
+          amountOut: trade.outputAmount.quotient.toString(),
+        }
         : {
-            currencyIn,
-            path: encodeRouteToPath(trade.route, exactOutput),
-            amountIn: trade.inputAmount.quotient.toString(),
-            amountOutMinimum: slippageTolerance ? trade.minimumAmountOut(slippageTolerance).quotient.toString() : 0,
-          },
+          currencyIn,
+          path: encodeRouteToPath(trade.route, exactOutput),
+          amountIn: trade.inputAmount.quotient.toString(),
+          amountOutMinimum: slippageTolerance ? trade.minimumAmountOut(slippageTolerance).quotient.toString() : 0,
+        },
     ])
     return this
   }


### PR DESCRIPTION
## Description

`v4-sdk` uses ethers v5, which is slowly going away. Many project that import `v4-sdk` may also have ethers-v6 in their dependency. This creates conflicts, because `v4-sdk` imports `ethers` directly (instead of importing `@ethersproject/xxx`).

## How Has This Been Tested?

This is only a change to the imports. There should be no feature changes. Was tested with `yarn test`

## Are there any breaking changes?

There shouldn't be any.

## Feedback Focus

The dependencies of the `v4-sdk` package do not include `ethers`. It only contains `@ethersproject/solidity`. However, `v4-sdk` does use features from all of the following
```
@ethersproject/abi
@ethersproject/address
@ethersproject/bignumber
@ethersproject/constants
@ethersproject/hash
@ethersproject/solidity
@ethersproject/units
@ethersproject/abstract-signer
```
Maybe they should be added to the dependencies in a more explicit way

## Follow Ups

Migration to ethers v6: https://github.com/Uniswap/sdks/issues/141