### PR TITLE
feat(v2-sdk): bump sdk-core to have v2-sdk factory address for Unichain

### DIFF
--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ethersproject/address": "^5.0.2",
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^5.9.0",
+    "@uniswap/sdk-core": "^6.0.0",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4539,7 +4539,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.1, @uniswap/sdk-core@npm:^5.8.2, @uniswap/sdk-core@npm:^5.9.0":
+"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.1, @uniswap/sdk-core@npm:^5.8.2":
   version: 5.9.0
   resolution: "@uniswap/sdk-core@npm:5.9.0"
   dependencies:
@@ -4553,6 +4553,23 @@ __metadata:
     tiny-invariant: ^1.1.0
     toformat: ^2.0.0
   checksum: 2bb52a473053f50da68254a9521f907fd34c3eb1c67cda9c0cbe1302da245fe5378a31afdad281a20618ec7f4b9be934c3badf8704a9ab2ae5296f90ae4725a8
+  languageName: node
+  linkType: hard
+
+"@uniswap/sdk-core@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@uniswap/sdk-core@npm:6.0.0"
+  dependencies:
+    "@ethersproject/address": ^5.0.2
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/keccak256": 5.7.0
+    "@ethersproject/strings": 5.7.0
+    big.js: ^5.2.2
+    decimal.js-light: ^2.5.0
+    jsbi: ^3.1.4
+    tiny-invariant: ^1.1.0
+    toformat: ^2.0.0
+  checksum: 395808ddb8425a98226fd5d19783067c29bdda6c8e6b05032a57a6c66db58870f8f6766b0d1c93bd9e15e4c646f283712bea8cb177aca7818234c3b3c743db2d
   languageName: node
   linkType: hard
 
@@ -4692,7 +4709,7 @@ __metadata:
     "@ethersproject/solidity": ^5.0.9
     "@types/big.js": ^4.0.5
     "@types/jest": ^24.0.25
-    "@uniswap/sdk-core": ^5.9.0
+    "@uniswap/sdk-core": ^6.0.0
     "@uniswap/v2-core": ^1.0.1
     eslint-config-react-app: 7.0.1
     tiny-invariant: ^1.1.0


### PR DESCRIPTION
## Description

Bump sdk-core in v2-sdk. This is needed because v2-sdk [FACTORY_ADDRESS_MAP](https://github.com/Uniswap/sdks/blob/main/sdks/v2-sdk/src/constants.ts#L9) uses V2_FACTORY_ADDRESSES from sdk-core

## How Has This Been Tested?

Will test in routing

## Are there any breaking changes?

Not really - besides new sdk-core renamed `Chain.ASTROCHAIN_SEPOLIA` TO `Chain.UNICHAIN_SEPOLIA`
