### PR TITLE
feat(v3-sdk): bump sdk-core to have Unichain chainId

### DIFF
--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^5.8.1",
+    "@uniswap/sdk-core": "^6.0.0",
     "@uniswap/swap-router-contracts": "^1.3.0",
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-staker": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4556,6 +4556,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uniswap/sdk-core@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@uniswap/sdk-core@npm:6.0.0"
+  dependencies:
+    "@ethersproject/address": ^5.0.2
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/keccak256": 5.7.0
+    "@ethersproject/strings": 5.7.0
+    big.js: ^5.2.2
+    decimal.js-light: ^2.5.0
+    jsbi: ^3.1.4
+    tiny-invariant: ^1.1.0
+    toformat: ^2.0.0
+  checksum: 395808ddb8425a98226fd5d19783067c29bdda6c8e6b05032a57a6c66db58870f8f6766b0d1c93bd9e15e4c646f283712bea8cb177aca7818234c3b3c743db2d
+  languageName: node
+  linkType: hard
+
 "@uniswap/sdk-core@workspace:sdks/sdk-core":
   version: 0.0.0-use.local
   resolution: "@uniswap/sdk-core@workspace:sdks/sdk-core"
@@ -4767,7 +4784,7 @@ __metadata:
     "@ethersproject/abi": ^5.5.0
     "@ethersproject/solidity": ^5.0.9
     "@types/jest": ^24.0.25
-    "@uniswap/sdk-core": ^5.8.1
+    "@uniswap/sdk-core": ^6.0.0
     "@uniswap/swap-router-contracts": ^1.3.0
     "@uniswap/v3-core": 1.0.0
     "@uniswap/v3-periphery": ^1.1.1


### PR DESCRIPTION
## Description

Bump sdk-core in v3-sdk. v3-sdk uses ChainId enum from sdk-core https://github.com/search?q=repo%3AUniswap%2Fsdks+sdk-core+path%3A%2F%5Esdks%5C%2Fv3-sdk%5C%2F%2F&type=code, so v3-sdk needs Unichain chain id

## How Has This Been Tested?

Will test in routing

## Are there any breaking changes?

Not really - besides new sdk-core renamed `Chain.ASTROCHAIN_SEPOLIA` to `Chain.UNICHAIN_SEPOLIA`