### PR TITLE
feat(router-sdk): bump sdk-core,v2-sdk,v3-sdk,v4-sdk in router-sdk for unichain weth9

### DIFF
--- a/sdks/router-sdk/package.json
+++ b/sdks/router-sdk/package.json
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
-    "@uniswap/sdk-core": "^5.8.0",
+    "@uniswap/sdk-core": "^6.0.0",
     "@uniswap/swap-router-contracts": "^1.3.0",
-    "@uniswap/v2-sdk": "^4.6.0",
-    "@uniswap/v3-sdk": "^3.17.0",
+    "@uniswap/v2-sdk": "^4.7.0",
+    "@uniswap/v3-sdk": "^3.19.0",
     "@uniswap/v4-sdk": "^1.10.3"
   },
   "devDependencies": {

--- a/sdks/router-sdk/package.json
+++ b/sdks/router-sdk/package.json
@@ -25,7 +25,7 @@
     "@uniswap/swap-router-contracts": "^1.3.0",
     "@uniswap/v2-sdk": "^4.7.0",
     "@uniswap/v3-sdk": "^3.19.0",
-    "@uniswap/v4-sdk": "^1.10.3"
+    "@uniswap/v4-sdk": "^1.12.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4529,10 +4529,10 @@ __metadata:
   dependencies:
     "@ethersproject/abi": ^5.5.0
     "@types/jest": ^24.0.25
-    "@uniswap/sdk-core": ^5.8.0
+    "@uniswap/sdk-core": ^6.0.0
     "@uniswap/swap-router-contracts": ^1.3.0
-    "@uniswap/v2-sdk": ^4.6.0
-    "@uniswap/v3-sdk": ^3.17.0
+    "@uniswap/v2-sdk": ^4.7.0
+    "@uniswap/v3-sdk": ^3.19.0
     "@uniswap/v4-sdk": ^1.10.3
     prettier: ^2.4.1
     tsdx: ^0.14.1
@@ -4701,6 +4701,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uniswap/v2-sdk@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "@uniswap/v2-sdk@npm:4.7.0"
+  dependencies:
+    "@ethersproject/address": ^5.0.2
+    "@ethersproject/solidity": ^5.0.9
+    "@uniswap/sdk-core": ^6.0.0
+    tiny-invariant: ^1.1.0
+    tiny-warning: ^1.0.3
+  checksum: 234f018ca2a42e76251bd15482f24a5f7c8987695e74681a62800bc0e878b3b0f0052490fd7d269408a5f269ca74befa15d2ab01f541596271e44aa0364258d7
+  languageName: node
+  linkType: hard
+
 "@uniswap/v2-sdk@workspace:sdks/v2-sdk":
   version: 0.0.0-use.local
   resolution: "@uniswap/v2-sdk@workspace:sdks/v2-sdk"
@@ -4774,6 +4787,22 @@ __metadata:
     tiny-invariant: ^1.1.0
     tiny-warning: ^1.0.3
   checksum: ab86fb564f3970b9ea8361781e026d539a1b7216d4d248280b619cac7ea9ab859431be38b464582ca1312f37f5ed05a1dc685af63eba4adf4e0148be473cbf21
+  languageName: node
+  linkType: hard
+
+"@uniswap/v3-sdk@npm:^3.19.0":
+  version: 3.19.0
+  resolution: "@uniswap/v3-sdk@npm:3.19.0"
+  dependencies:
+    "@ethersproject/abi": ^5.5.0
+    "@ethersproject/solidity": ^5.0.9
+    "@uniswap/sdk-core": ^6.0.0
+    "@uniswap/swap-router-contracts": ^1.3.0
+    "@uniswap/v3-periphery": ^1.1.1
+    "@uniswap/v3-staker": 1.0.0
+    tiny-invariant: ^1.1.0
+    tiny-warning: ^1.0.3
+  checksum: b076fa983838694ee7c38ebfbe5fb211514f5b5d5b37089b79ddc2a5684cd11cc32bc4f7182ed0db99f7f46b08a850397991702078bd6043103f35cf36cb6a84
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4539,7 +4539,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.1, @uniswap/sdk-core@npm:^5.8.2":
+"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.2":
   version: 5.9.0
   resolution: "@uniswap/sdk-core@npm:5.9.0"
   dependencies:
@@ -4688,20 +4688,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uniswap/v2-sdk@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "@uniswap/v2-sdk@npm:4.6.0"
-  dependencies:
-    "@ethersproject/address": ^5.0.2
-    "@ethersproject/solidity": ^5.0.9
-    "@uniswap/sdk-core": ^5.8.0
-    tiny-invariant: ^1.1.0
-    tiny-warning: ^1.0.3
-  checksum: 7ec46ca0780892adaadbab546b05d628cb2aaaef7198f3f92021e10e3adbbf42566ae0f6d7ae1c55afa01f894164b4b8f450cc91f718059a19f5a333115a5f68
-  languageName: node
-  linkType: hard
-
-"@uniswap/v2-sdk@npm:^4.7.0":
+"@uniswap/v2-sdk@npm:^4.6.0, @uniswap/v2-sdk@npm:^4.7.0":
   version: 4.7.0
   resolution: "@uniswap/v2-sdk@npm:4.7.0"
   dependencies:
@@ -4774,23 +4761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uniswap/v3-sdk@npm:^3.17.0, @uniswap/v3-sdk@npm:^3.18.1":
-  version: 3.18.1
-  resolution: "@uniswap/v3-sdk@npm:3.18.1"
-  dependencies:
-    "@ethersproject/abi": ^5.5.0
-    "@ethersproject/solidity": ^5.0.9
-    "@uniswap/sdk-core": ^5.8.1
-    "@uniswap/swap-router-contracts": ^1.3.0
-    "@uniswap/v3-periphery": ^1.1.1
-    "@uniswap/v3-staker": 1.0.0
-    tiny-invariant: ^1.1.0
-    tiny-warning: ^1.0.3
-  checksum: ab86fb564f3970b9ea8361781e026d539a1b7216d4d248280b619cac7ea9ab859431be38b464582ca1312f37f5ed05a1dc685af63eba4adf4e0148be473cbf21
-  languageName: node
-  linkType: hard
-
-"@uniswap/v3-sdk@npm:^3.19.0":
+"@uniswap/v3-sdk@npm:^3.17.0, @uniswap/v3-sdk@npm:^3.18.1, @uniswap/v3-sdk@npm:^3.19.0":
   version: 3.19.0
   resolution: "@uniswap/v3-sdk@npm:3.19.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4533,13 +4533,13 @@ __metadata:
     "@uniswap/swap-router-contracts": ^1.3.0
     "@uniswap/v2-sdk": ^4.7.0
     "@uniswap/v3-sdk": ^3.19.0
-    "@uniswap/v4-sdk": ^1.10.3
+    "@uniswap/v4-sdk": ^1.12.0
     prettier: ^2.4.1
     tsdx: ^0.14.1
   languageName: unknown
   linkType: soft
 
-"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.2":
+"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.1, @uniswap/sdk-core@npm:^5.8.2":
   version: 5.9.0
   resolution: "@uniswap/sdk-core@npm:5.9.0"
   dependencies:
@@ -4688,7 +4688,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uniswap/v2-sdk@npm:^4.6.0, @uniswap/v2-sdk@npm:^4.7.0":
+"@uniswap/v2-sdk@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "@uniswap/v2-sdk@npm:4.6.0"
+  dependencies:
+    "@ethersproject/address": ^5.0.2
+    "@ethersproject/solidity": ^5.0.9
+    "@uniswap/sdk-core": ^5.8.0
+    tiny-invariant: ^1.1.0
+    tiny-warning: ^1.0.3
+  checksum: 7ec46ca0780892adaadbab546b05d628cb2aaaef7198f3f92021e10e3adbbf42566ae0f6d7ae1c55afa01f894164b4b8f450cc91f718059a19f5a333115a5f68
+  languageName: node
+  linkType: hard
+
+"@uniswap/v2-sdk@npm:^4.7.0":
   version: 4.7.0
   resolution: "@uniswap/v2-sdk@npm:4.7.0"
   dependencies:
@@ -4761,7 +4774,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uniswap/v3-sdk@npm:3.19.0":
+"@uniswap/v3-sdk@npm:3.19.0, @uniswap/v3-sdk@npm:^3.19.0":
   version: 3.19.0
   resolution: "@uniswap/v3-sdk@npm:3.19.0"
   dependencies:
@@ -4780,19 +4793,16 @@ __metadata:
 "@uniswap/v3-sdk@npm:^3.17.0, @uniswap/v3-sdk@npm:^3.18.1":
   version: 3.18.1
   resolution: "@uniswap/v3-sdk@npm:3.18.1"
-"@uniswap/v3-sdk@npm:^3.17.0, @uniswap/v3-sdk@npm:^3.18.1, @uniswap/v3-sdk@npm:^3.19.0":
-  version: 3.19.0
-  resolution: "@uniswap/v3-sdk@npm:3.19.0"
   dependencies:
     "@ethersproject/abi": ^5.5.0
     "@ethersproject/solidity": ^5.0.9
-    "@uniswap/sdk-core": ^6.0.0
+    "@uniswap/sdk-core": ^5.8.1
     "@uniswap/swap-router-contracts": ^1.3.0
     "@uniswap/v3-periphery": ^1.1.1
     "@uniswap/v3-staker": 1.0.0
     tiny-invariant: ^1.1.0
     tiny-warning: ^1.0.3
-  checksum: b076fa983838694ee7c38ebfbe5fb211514f5b5d5b37089b79ddc2a5684cd11cc32bc4f7182ed0db99f7f46b08a850397991702078bd6043103f35cf36cb6a84
+  checksum: ab86fb564f3970b9ea8361781e026d539a1b7216d4d248280b619cac7ea9ab859431be38b464582ca1312f37f5ed05a1dc685af63eba4adf4e0148be473cbf21
   languageName: node
   linkType: hard
 
@@ -4836,6 +4846,19 @@ __metadata:
     tiny-invariant: ^1.1.0
     tiny-warning: ^1.0.3
   checksum: ca0565f4e87c2b306dc642ca13b7e2605a994cf5e9cb661503a60a3cc8dd86727f73328ebd529f9a42cedf6751dde91735b4ff7e3468deef37fa254d47e3ee9b
+  languageName: node
+  linkType: hard
+
+"@uniswap/v4-sdk@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "@uniswap/v4-sdk@npm:1.12.0"
+  dependencies:
+    "@ethersproject/solidity": ^5.0.9
+    "@uniswap/sdk-core": ^6.0.0
+    "@uniswap/v3-sdk": 3.19.0
+    tiny-invariant: ^1.1.0
+    tiny-warning: ^1.0.3
+  checksum: 975b88da4b70cc3fe66fe768ad94b2019ac4c70d9601ac148e6c8081a53d26fdd77cc77f1bf286faec1072d13463608ff629c59820f2f0aa7f7bd16a46cb328c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

bump sdk-core,v2-sdk,v3-sdk,v4-sdk in router-sdk for unichain weth9. router-sdk has [weth9](https://github.com/search?q=repo%3AUniswap%2Fsdks+weth9+path%3A%2F%5Esdks%5C%2Frouter-sdk%5C%2Fsrc%5C%2F%2F&type=code), so it needs it from sdk-core 

## How Has This Been Tested?

Will test in routing

## Are there any breaking changes?

No