### PR TITLE
feat(v4-sdk): bump sdk-core, v3-sdk for syncd Unichain support in router-sdk

### DIFF
--- a/.github/workflows/monorepo-integrity.yml
+++ b/.github/workflows/monorepo-integrity.yml
@@ -43,8 +43,8 @@ jobs:
         run: yarn g:check:deps:mismatch
 
       # This check will be disabled while a major version change of sdk-core is underway
-      - name: 👬🏽 Check for duplicate dependencies in lock file
-        run: yarn dedupe --check
+#      - name: 👬🏽 Check for duplicate dependencies in lock file
+#        run: yarn dedupe --check
 
       - name: 🧑‍⚖️ Check for yarn constraints.pro
         run: yarn constraints

--- a/sdks/v4-sdk/package.json
+++ b/sdks/v4-sdk/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^5.3.1",
-    "@uniswap/v3-sdk": "3.12.0",
+    "@uniswap/sdk-core": "^6.0.0",
+    "@uniswap/v3-sdk": "3.19.0",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4539,7 +4539,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.1, @uniswap/sdk-core@npm:^5.8.2":
+"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.2":
   version: 5.9.0
   resolution: "@uniswap/sdk-core@npm:5.9.0"
   dependencies:
@@ -4761,7 +4761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uniswap/v3-sdk@npm:3.19.0":
+"@uniswap/v3-sdk@npm:3.19.0, @uniswap/v3-sdk@npm:^3.17.0, @uniswap/v3-sdk@npm:^3.18.1":
   version: 3.19.0
   resolution: "@uniswap/v3-sdk@npm:3.19.0"
   dependencies:
@@ -4774,22 +4774,6 @@ __metadata:
     tiny-invariant: ^1.1.0
     tiny-warning: ^1.0.3
   checksum: b076fa983838694ee7c38ebfbe5fb211514f5b5d5b37089b79ddc2a5684cd11cc32bc4f7182ed0db99f7f46b08a850397991702078bd6043103f35cf36cb6a84
-  languageName: node
-  linkType: hard
-
-"@uniswap/v3-sdk@npm:^3.17.0, @uniswap/v3-sdk@npm:^3.18.1":
-  version: 3.18.1
-  resolution: "@uniswap/v3-sdk@npm:3.18.1"
-  dependencies:
-    "@ethersproject/abi": ^5.5.0
-    "@ethersproject/solidity": ^5.0.9
-    "@uniswap/sdk-core": ^5.8.1
-    "@uniswap/swap-router-contracts": ^1.3.0
-    "@uniswap/v3-periphery": ^1.1.1
-    "@uniswap/v3-staker": 1.0.0
-    tiny-invariant: ^1.1.0
-    tiny-warning: ^1.0.3
-  checksum: ab86fb564f3970b9ea8361781e026d539a1b7216d4d248280b619cac7ea9ab859431be38b464582ca1312f37f5ed05a1dc685af63eba4adf4e0148be473cbf21
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4761,6 +4761,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uniswap/v3-sdk@npm:3.19.0":
+  version: 3.19.0
+  resolution: "@uniswap/v3-sdk@npm:3.19.0"
+  dependencies:
+    "@ethersproject/abi": ^5.5.0
+    "@ethersproject/solidity": ^5.0.9
+    "@uniswap/sdk-core": ^6.0.0
+    "@uniswap/swap-router-contracts": ^1.3.0
+    "@uniswap/v3-periphery": ^1.1.1
+    "@uniswap/v3-staker": 1.0.0
+    tiny-invariant: ^1.1.0
+    tiny-warning: ^1.0.3
+  checksum: b076fa983838694ee7c38ebfbe5fb211514f5b5d5b37089b79ddc2a5684cd11cc32bc4f7182ed0db99f7f46b08a850397991702078bd6043103f35cf36cb6a84
+  languageName: node
+  linkType: hard
+
 "@uniswap/v3-sdk@npm:^3.17.0, @uniswap/v3-sdk@npm:^3.18.1":
   version: 3.18.1
   resolution: "@uniswap/v3-sdk@npm:3.18.1"
@@ -4829,8 +4845,8 @@ __metadata:
     "@types/mocha": ^9.1.1
     "@types/node": ^18.7.16
     "@types/node-fetch": ^2.6.2
-    "@uniswap/sdk-core": ^5.3.1
-    "@uniswap/v3-sdk": 3.12.0
+    "@uniswap/sdk-core": ^6.0.0
+    "@uniswap/v3-sdk": 3.19.0
     chai: ^4.3.6
     dotenv: ^16.0.3
     eslint-plugin-prettier: ^3.4.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -4539,7 +4539,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.2":
+"@uniswap/sdk-core@npm:^5.0.0, @uniswap/sdk-core@npm:^5.3.0, @uniswap/sdk-core@npm:^5.3.1, @uniswap/sdk-core@npm:^5.8.0, @uniswap/sdk-core@npm:^5.8.1, @uniswap/sdk-core@npm:^5.8.2":
   version: 5.9.0
   resolution: "@uniswap/sdk-core@npm:5.9.0"
   dependencies:
@@ -4761,7 +4761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uniswap/v3-sdk@npm:3.19.0, @uniswap/v3-sdk@npm:^3.17.0, @uniswap/v3-sdk@npm:^3.18.1":
+"@uniswap/v3-sdk@npm:3.19.0":
   version: 3.19.0
   resolution: "@uniswap/v3-sdk@npm:3.19.0"
   dependencies:
@@ -4774,6 +4774,22 @@ __metadata:
     tiny-invariant: ^1.1.0
     tiny-warning: ^1.0.3
   checksum: b076fa983838694ee7c38ebfbe5fb211514f5b5d5b37089b79ddc2a5684cd11cc32bc4f7182ed0db99f7f46b08a850397991702078bd6043103f35cf36cb6a84
+  languageName: node
+  linkType: hard
+
+"@uniswap/v3-sdk@npm:^3.17.0, @uniswap/v3-sdk@npm:^3.18.1":
+  version: 3.18.1
+  resolution: "@uniswap/v3-sdk@npm:3.18.1"
+  dependencies:
+    "@ethersproject/abi": ^5.5.0
+    "@ethersproject/solidity": ^5.0.9
+    "@uniswap/sdk-core": ^5.8.1
+    "@uniswap/swap-router-contracts": ^1.3.0
+    "@uniswap/v3-periphery": ^1.1.1
+    "@uniswap/v3-staker": 1.0.0
+    tiny-invariant: ^1.1.0
+    tiny-warning: ^1.0.3
+  checksum: ab86fb564f3970b9ea8361781e026d539a1b7216d4d248280b619cac7ea9ab859431be38b464582ca1312f37f5ed05a1dc685af63eba4adf4e0148be473cbf21
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Need to bump `v3-sdk`, `sdk-core` before bumping `router-sdk` in [this PR](https://github.com/Uniswap/sdks/pull/202) otherwise build complains.

### Note:
temporarily disabling `yarn dedupe --check`  as there are some dependency issues between router-sdk and v4-sdk. Will re-enable in this [router-sdk PR](https://github.com/Uniswap/sdks/pull/202)

## How Has This Been Tested?

Will test in routing

## Are there any breaking changes?

No AFAIK