### PR TITLE
fix(uniswapx-sdk): DutchV3 order parsing

### DIFF
--- a/sdks/uniswapx-sdk/src/utils/order.test.ts
+++ b/sdks/uniswapx-sdk/src/utils/order.test.ts
@@ -39,7 +39,7 @@ describe("order utils", () => {
   const uniswapXOrderParser = new UniswapXOrderParser();
   const relayOrderParser = new RelayOrderParser();
 
-  beforeAll(async () => {
+  beforeAll(() => {
     chainId = 1;
     priorityChainId = 8453;
     blockBasedChainId = 42161;
@@ -454,7 +454,6 @@ describe("order utils", () => {
           blockBasedChainId
         )
       ).toEqual(OrderType.Dutch_V3);
-      console.log(unsignedV3DutchOrder.serialize());
     });
     it("parses CosignedV3DutchOrder type", () => {
       expect(


### PR DESCRIPTION
Addressing a gap in tests for using the Order Parser on unsigned & cosigned DutchV3 orders
Labelled as fix to trigger npm patch release with latest commits