### PR TITLE
perf(v3-sdk): refactor `fromRoute(s)` for clarity and efficiency

### DIFF
--- a/sdks/v3-sdk/src/entities/trade.ts
+++ b/sdks/v3-sdk/src/entities/trade.ts
@@ -228,32 +228,24 @@ export class Trade<TInput extends Currency, TOutput extends Currency, TTradeType
     amount: TTradeType extends TradeType.EXACT_INPUT ? CurrencyAmount<TInput> : CurrencyAmount<TOutput>,
     tradeType: TTradeType
   ): Promise<Trade<TInput, TOutput, TTradeType>> {
-    const amounts: CurrencyAmount<Token>[] = new Array(route.tokenPath.length)
+    let tokenAmount: CurrencyAmount<Token> = amount.wrapped
     let inputAmount: CurrencyAmount<TInput>
     let outputAmount: CurrencyAmount<TOutput>
     if (tradeType === TradeType.EXACT_INPUT) {
       invariant(amount.currency.equals(route.input), 'INPUT')
-      amounts[0] = amount.wrapped
-      for (let i = 0; i < route.tokenPath.length - 1; i++) {
+      for (let i = 0; i < route.pools.length; i++) {
         const pool = route.pools[i]
-        const [outputAmount] = await pool.getOutputAmount(amounts[i])
-        amounts[i + 1] = outputAmount
+        ;[tokenAmount] = await pool.getOutputAmount(tokenAmount)
       }
       inputAmount = CurrencyAmount.fromFractionalAmount(route.input, amount.numerator, amount.denominator)
-      outputAmount = CurrencyAmount.fromFractionalAmount(
-        route.output,
-        amounts[amounts.length - 1].numerator,
-        amounts[amounts.length - 1].denominator
-      )
+      outputAmount = CurrencyAmount.fromFractionalAmount(route.output, tokenAmount.numerator, tokenAmount.denominator)
     } else {
       invariant(amount.currency.equals(route.output), 'OUTPUT')
-      amounts[amounts.length - 1] = amount.wrapped
-      for (let i = route.tokenPath.length - 1; i > 0; i--) {
-        const pool = route.pools[i - 1]
-        const [inputAmount] = await pool.getInputAmount(amounts[i])
-        amounts[i - 1] = inputAmount
+      for (let i = route.pools.length - 1; i >= 0; i--) {
+        const pool = route.pools[i]
+        ;[tokenAmount] = await pool.getInputAmount(tokenAmount)
       }
-      inputAmount = CurrencyAmount.fromFractionalAmount(route.input, amounts[0].numerator, amounts[0].denominator)
+      inputAmount = CurrencyAmount.fromFractionalAmount(route.input, tokenAmount.numerator, tokenAmount.denominator)
       outputAmount = CurrencyAmount.fromFractionalAmount(route.output, amount.numerator, amount.denominator)
     }
 
@@ -284,49 +276,12 @@ export class Trade<TInput extends Currency, TOutput extends Currency, TTradeType
       route: Route<TInput, TOutput>
       inputAmount: CurrencyAmount<TInput>
       outputAmount: CurrencyAmount<TOutput>
-    }[] = []
-
-    for (const { route, amount } of routes) {
-      const amounts: CurrencyAmount<Token>[] = new Array(route.tokenPath.length)
-      let inputAmount: CurrencyAmount<TInput>
-      let outputAmount: CurrencyAmount<TOutput>
-
-      if (tradeType === TradeType.EXACT_INPUT) {
-        invariant(amount.currency.equals(route.input), 'INPUT')
-        inputAmount = CurrencyAmount.fromFractionalAmount(route.input, amount.numerator, amount.denominator)
-        amounts[0] = CurrencyAmount.fromFractionalAmount(route.input.wrapped, amount.numerator, amount.denominator)
-
-        for (let i = 0; i < route.tokenPath.length - 1; i++) {
-          const pool = route.pools[i]
-          const [outputAmount] = await pool.getOutputAmount(amounts[i])
-          amounts[i + 1] = outputAmount
-        }
-
-        outputAmount = CurrencyAmount.fromFractionalAmount(
-          route.output,
-          amounts[amounts.length - 1].numerator,
-          amounts[amounts.length - 1].denominator
-        )
-      } else {
-        invariant(amount.currency.equals(route.output), 'OUTPUT')
-        outputAmount = CurrencyAmount.fromFractionalAmount(route.output, amount.numerator, amount.denominator)
-        amounts[amounts.length - 1] = CurrencyAmount.fromFractionalAmount(
-          route.output.wrapped,
-          amount.numerator,
-          amount.denominator
-        )
-
-        for (let i = route.tokenPath.length - 1; i > 0; i--) {
-          const pool = route.pools[i - 1]
-          const [inputAmount] = await pool.getInputAmount(amounts[i])
-          amounts[i - 1] = inputAmount
-        }
-
-        inputAmount = CurrencyAmount.fromFractionalAmount(route.input, amounts[0].numerator, amounts[0].denominator)
-      }
-
-      populatedRoutes.push({ route, inputAmount, outputAmount })
-    }
+    }[] = await Promise.all(
+      routes.map(async ({ amount, route }) => {
+        const trade = await Trade.fromRoute(route, amount, tradeType)
+        return trade.swaps[0]
+      })
+    )
 
     return new Trade({
       routes: populatedRoutes,


### PR DESCRIPTION
## Description

Simplify the `fromRoute` and `fromRoutes` methods by reducing redundant code. Utilize a more concise approach to calculating input and output amounts, enhancing both clarity and efficiency.

## How Has This Been Tested?

Unit tests.

## Are there any breaking changes?

No.

Same as #184 but for V3.