### PR TITLE
refactor(v3-sdk): simplify `midPrice` in `Route` entity

### DIFF
--- a/sdks/v3-sdk/src/entities/route.ts
+++ b/sdks/v3-sdk/src/entities/route.ts
@@ -61,28 +61,9 @@ export class Route<TInput extends Currency, TOutput extends Currency> {
   public get midPrice(): Price<TInput, TOutput> {
     if (this._midPrice !== null) return this._midPrice
 
-    const price = this.pools.slice(1).reduce(
-      ({ nextInput, price }, pool) => {
-        return nextInput.equals(pool.token0)
-          ? {
-              nextInput: pool.token1,
-              price: price.multiply(pool.token0Price),
-            }
-          : {
-              nextInput: pool.token0,
-              price: price.multiply(pool.token1Price),
-            }
-      },
-      this.pools[0].token0.equals(this.input.wrapped)
-        ? {
-            nextInput: this.pools[0].token1,
-            price: this.pools[0].token0Price,
-          }
-        : {
-            nextInput: this.pools[0].token0,
-            price: this.pools[0].token1Price,
-          }
-    ).price
+    const price = this.pools.slice(1).reduce((price, pool) => {
+      return price.multiply(pool.priceOf(price.quoteCurrency))
+    }, this.pools[0].priceOf(this.input.wrapped))
 
     return (this._midPrice = new Price(this.input, this.output, price.denominator, price.numerator))
   }


### PR DESCRIPTION
## Description

Simplify the `midPrice` calculation by removing complex logic and utilizing `priceOf` method directly. This change improves code readability and maintainability, reducing potential points of failure.

## How Has This Been Tested?

Unit tests.

## Are there any breaking changes?

No.

Same as #180 but for V3.