### PR TITLE
fix(sdk-core): update v4 testnets addresses

### DIFF
--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -165,6 +165,11 @@ const ARBITRUM_SEPOLIA_ADDRESSES: ChainAddresses = {
   nonfungiblePositionManagerAddress: '0x6b2937Bde17889EDCf8fbD8dE31C3C2a70Bc4d65',
   tickLensAddress: '0x0fd18587734e5C2dcE2dccDcC7DD1EC89ba557d9',
   swapRouter02Address: '0x101F443B4d1b059569D643917553c771E1b9663E',
+
+  v4PoolManagerAddress: '0xFB3e0C6F74eB1a21CC1Da29aeC80D2Dfe6C9a317',
+  v4PositionManagerAddress: '0xAc631556d3d4019C95769033B5E719dD77124BAc',
+  v4StateView: '0x9d467fa9062b6e9b1a46e26007ad82db116c67cb',
+  v4QuoterAddress: '0x7de51022d70a725b508085468052e25e22b5c4c9',
 }
 
 // sepolia v3 addresses
@@ -181,10 +186,10 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   mixedRouteQuoterV2Address: '0x4745f77b56a0e2294426e3936dc4fab68d9543cd',
 
   // TODO: update all below once v4 on sepolia redeployed
-  v4PoolManagerAddress: '0x00b036b58a818b1bc34d502d3fe730db729e62ac',
-  v4PositionManagerAddress: '0xf969aee60879c54baaed9f3ed26147db216fd664',
-  v4StateView: '0xc199f1072a74d4e905aba1a84d9a45e2546b6222',
-  v4QuoterAddress: '0x56dcd40a3f2d466f48e7f48bdbe5cc9b92ae4472',
+  v4PoolManagerAddress: '0xE03A1074c86CFeDd5C142C4F04F1a1536e203543',
+  v4PositionManagerAddress: '0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4',
+  v4StateView: '0xe1dd9c3fa50edb962e442f60dfbc432e24537e4c',
+  v4QuoterAddress: '0x61b3f2011a92d183c7dbadbda940a7555ccf9227',
 }
 
 // Avalanche v3 addresses
@@ -288,10 +293,10 @@ const UNICHAIN_SEPOLIA_ADDRESSES: ChainAddresses = {
   tickLensAddress: '0x5f739c790a48E97eec0efb81bab5D152c0A0ecA0',
   swapRouter02Address: '0xd1AAE39293221B77B0C71fBD6dCb7Ea29Bb5B166',
 
-  v4PoolManagerAddress: '0x38EB8B22Df3Ae7fb21e92881151B365Df14ba967',
-  v4PositionManagerAddress: '0x05deD3F8a8e84700d68A4D81cd6780c982dB13F9',
-  v4StateView: '0xad328439DCa7ce857662afA4584A3d571bbDDC75',
-  v4QuoterAddress: '0x2cfa87651D3AB05Bc59E325E5eaC8495CF34cE55',
+  v4PoolManagerAddress: '0x00b036b58a818b1bc34d502d3fe730db729e62ac',
+  v4PositionManagerAddress: '0xf969aee60879c54baaed9f3ed26147db216fd664',
+  v4StateView: '0xc199f1072a74d4e905aba1a84d9a45e2546b6222',
+  v4QuoterAddress: '0x56dcd40a3f2d466f48e7f48bdbe5cc9b92ae4472',
 }
 
 const UNICHAIN_ADDRESSES: ChainAddresses = {

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -181,10 +181,10 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   mixedRouteQuoterV2Address: '0x4745f77b56a0e2294426e3936dc4fab68d9543cd',
 
   // TODO: update all below once v4 on sepolia redeployed
-  v4PoolManagerAddress: '0x8C4BcBE6b9eF47855f97E675296FA3F6fafa5F1A',
-  v4PositionManagerAddress: '0x1B1C77B606d13b09C84d1c7394B96b147bC03147',
-  v4StateView: '0x823d45b1329bcF3b369F08F36ba2690Ff8e058C3',
-  v4QuoterAddress: '0xCd8716395D55aD17496448a4b2C42557001e9743',
+  v4PoolManagerAddress: '0x00b036b58a818b1bc34d502d3fe730db729e62ac',
+  v4PositionManagerAddress: '0xf969aee60879c54baaed9f3ed26147db216fd664',
+  v4StateView: '0xc199f1072a74d4e905aba1a84d9a45e2546b6222',
+  v4QuoterAddress: '0x56dcd40a3f2d466f48e7f48bdbe5cc9b92ae4472',
 }
 
 // Avalanche v3 addresses


### PR DESCRIPTION
## Description

Re-deployed v4.

## How Has This Been Tested?

Will test in routing

## Are there any breaking changes?

No, but this address only works with v4-sdk @uniswap/v4-sdk-v1.12.3+

## (Optional) Feedback Focus


## (Optional) Follow Ups