### PR TITLE
feat(breaking): esm/cjs builds for uniswapx-sdk

### DIFF
--- a/sdks/uniswapx-sdk/.eslintrc.json
+++ b/sdks/uniswapx-sdk/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.base.json"
   },
   "env": {
     "es6": true

--- a/sdks/uniswapx-sdk/integration/package.json
+++ b/sdks/uniswapx-sdk/integration/package.json
@@ -24,8 +24,7 @@
     "chai": "^4.3.6",
     "hardhat": "^2.22.15",
     "husky": "^8.0.3",
-    "ts-node": "^10.9.1",
-    "tsdx": "^0.14.1"
+    "ts-node": "^10.9.1"
   },
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",

--- a/sdks/uniswapx-sdk/integration/test/PriorityOrder.spec.ts
+++ b/sdks/uniswapx-sdk/integration/test/PriorityOrder.spec.ts
@@ -10,7 +10,7 @@ import Permit2Abi from "../../abis/Permit2.json";
 import MockERC20Abi from "../../abis/MockERC20.json";
 
 import { Permit2, PriorityOrderReactor, MockERC20 } from "../../src/contracts";
-import { PriorityOrderBuilder, PriorityCosignerData } from "../../dist/src";
+import { PriorityOrderBuilder, PriorityCosignerData } from "../../src";
 
 describe("PriorityOrder", () => {
   const FEE_RECIPIENT = "0x1111111111111111111111111111111111111111";

--- a/sdks/uniswapx-sdk/integration/test/PriorityOrderValidator.spec.ts
+++ b/sdks/uniswapx-sdk/integration/test/PriorityOrderValidator.spec.ts
@@ -19,7 +19,7 @@ import {
   OrderValidation,
   PriorityCosignerData,
   CosignedPriorityOrder,
-} from "../../dist/src";
+} from "../../src";
 import { StaticJsonRpcProvider } from "@ethersproject/providers";
 import { REACTOR_ADDRESS_MAPPING, UNISWAPX_ORDER_QUOTER_MAPPING } from "../../src/constants";
 import { parseEther } from "ethers/lib/utils";

--- a/sdks/uniswapx-sdk/integration/test/RelayOrderValidator.spec.ts
+++ b/sdks/uniswapx-sdk/integration/test/RelayOrderValidator.spec.ts
@@ -17,7 +17,7 @@ import {
   RelayOrderBuilder,
   RelayOrderValidator,
   RelayOrder,
-} from "../../dist/src";
+} from "../../src";
 import { deployAndReturnPermit2 } from "./utils/permit2";
 import { deployMulticall3 } from "./utils/multicall";
 

--- a/sdks/uniswapx-sdk/integration/test/V3DutchOrder.spec.ts
+++ b/sdks/uniswapx-sdk/integration/test/V3DutchOrder.spec.ts
@@ -4,7 +4,7 @@ import Permit2Abi from "../../abis/Permit2.json"
 import V3DutchOrderReactorAbi from "../../abis/V3DutchOrderReactor.json"
 import MockERC20Abi from "../../abis/MockERC20.json"
 import { Permit2, V3DutchOrderReactor } from "../../src/contracts"
-import { MockERC20 } from "../../dist/src/contracts";
+import { MockERC20 } from "../../src/contracts";
 import { BlockchainTime } from "./utils/time";
 import { V3DutchOrderBuilder } from "../../src/builder/V3DutchOrderBuilder"
 import { expect } from "chai";

--- a/sdks/uniswapx-sdk/jest.config.js
+++ b/sdks/uniswapx-sdk/jest.config.js
@@ -2,4 +2,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.base.json'
+    }
+  }
 };

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -7,9 +7,9 @@
     "ethereum"
   ],
   "license": "MIT",
-  "main": "dist/src/index.js",
-  "typings": "dist/src/index.d.ts",
-  "module": "dist/uniswapx-sdk.esm.js",
+  "main": "./dist/cjs/src/index.js",
+  "typings": "./dist/types/src/index.d.ts",
+  "module": "./dist/esm/src/index.js",
   "files": [
     "dist"
   ],
@@ -17,14 +17,17 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "yarn run typechain && tsc -p tsconfig.json",
+    "build": "yarn run typechain && yarn build:cjs && yarn build:esm && yarn build:types",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "prettier": "prettier \"src/**/*.ts\" --list-different",
     "release": "semantic-release",
-    "test": "run-s build test:unit test:integration",
+    "test": "run-s test:unit test:integration",
     "test:unit": "jest --testPathPattern src --detectOpenHandles --forceExit --testPathIgnorePatterns dist",
-    "test:integration": "yarn build && cd integration && yarn && yarn test",
+    "test:integration": "cd integration && yarn && yarn test",
     "typechain": "typechain --target=ethers-v5 --out-dir src/contracts --glob ./abis/**/*.json"
   },
   "dependencies": {
@@ -96,5 +99,13 @@
         }
       ]
     ]
-  }
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/types/src/index.d.ts",
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js"
+    }
+  },
+  "sideEffects": false
 }

--- a/sdks/uniswapx-sdk/tsconfig.base.json
+++ b/sdks/uniswapx-sdk/tsconfig.base.json
@@ -1,11 +1,9 @@
 {
-  "include": [
-    "src"
-  ],
+  "include": ["src", "abis"],
   "compilerOptions": {
-    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": ".",
     "target": "es6",
-    "module": "commonjs",
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
@@ -23,6 +21,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
-  },
-}
+    "skipLibCheck": true,
+    "isolatedModules": true
+  }
+} 

--- a/sdks/uniswapx-sdk/tsconfig.cjs.json
+++ b/sdks/uniswapx-sdk/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs"
+  }
+} 

--- a/sdks/uniswapx-sdk/tsconfig.esm.json
+++ b/sdks/uniswapx-sdk/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+} 

--- a/sdks/uniswapx-sdk/tsconfig.types.json
+++ b/sdks/uniswapx-sdk/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types"
+  }
+} 

--- a/turbo.json
+++ b/turbo.json
@@ -13,11 +13,16 @@
         "sdks/*/src/**.ts",
         "sdks/*/src/**.tsx"
       ],
-      "outputs": []
+      "outputs": [
+        "sdks/*/dist/**"
+      ]
     },
     "test": {
       "dependsOn": [
         "build"
+      ],
+      "inputs": [
+        "sdks/*/dist/**"
       ]
     },
     "release": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17616,7 +17616,6 @@ __metadata:
     hardhat: ^2.22.15
     husky: ^8.0.3
     ts-node: ^10.9.1
-    tsdx: ^0.14.1
     typechain: ^8.1.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## PR Scope

breaking change to build structure for `uniswapx-sdk`

## Description

updates the build setup for `uniswapx-sdk` to manually and explicitly create separate cjs and esm builds (plus a types-only version)



## How Has This Been Tested?

built the sdk locally, then installed the local build result in another project (`universe/apps/web`) and verified that it properly resolved the esm version instead of the cjs version

## Are there any breaking changes?

there shouldn't be, but technically if an end user is importing incorrectly (by directly referencing the `uniswapx-sdk.esm.js` file) then they'll need to update


## (Optional) Follow Ups

 PRs to follow will do this for many other SDKs