### PR TITLE
feat(v4-sdk): bump sdk-core to 7.1.0 for base sepolia and monad testnet in v4-sdk

### DIFF
--- a/sdks/v4-sdk/package.json
+++ b/sdks/v4-sdk/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@ethersproject/solidity": "^5.0.9",
-    "@uniswap/sdk-core": "^6.1.1",
+    "@uniswap/sdk-core": "^7.1.0",
     "@uniswap/v3-sdk": "3.20.0",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4830,7 +4830,7 @@ __metadata:
     "@types/mocha": ^9.1.1
     "@types/node": ^18.7.16
     "@types/node-fetch": ^2.6.2
-    "@uniswap/sdk-core": ^6.1.1
+    "@uniswap/sdk-core": ^7.1.0
     "@uniswap/v3-sdk": 3.20.0
     chai: ^4.3.6
     dotenv: ^16.0.3


### PR DESCRIPTION
## Description

Release https://github.com/Uniswap/sdks/pull/242 https://github.com/Uniswap/sdks/pull/240

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

_[e.g. Type definitions, API definitions]_

If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_
