### PR TITLE
fix(v2-sdk): Use type-based undefined check for kLast

### DIFF
--- a/sdks/v2-sdk/src/entities/pair.ts
+++ b/sdks/v2-sdk/src/entities/pair.ts
@@ -357,7 +357,7 @@ export class Pair {
     if (!feeOn) {
       totalSupplyAdjusted = totalSupply
     } else {
-      invariant(!!kLast, 'K_LAST')
+      invariant(typeof kLast !== 'undefined', 'K_LAST')
       const kLastParsed = JSBI.BigInt(kLast)
       if (!JSBI.equal(kLastParsed, ZERO)) {
         const rootK = sqrt(JSBI.multiply(this.reserve0.quotient, this.reserve1.quotient))


### PR DESCRIPTION
## Description

There is a bug in the V2 SDK where `kLast`—which can be `Bigintish` or `undefined`—is checked using `!!kLast`. This causes issues when `kLast = 0`, as `!!kLast` evaluates to `false`, incorrectly triggering an invariant error. Since there is already existing logic for handling `kLast = 0`, the proper check should ensure `kLast` is not `undefined`.

## How Has This Been Tested?

Manual Testing: Verified that when kLast = 0, no error is thrown.
Unit Tests: Existing unit tests were run to confirm no regressions.

## Are there any breaking changes?

No, this is not a breaking change. It only adjusts the check to correctly handle 0 as a valid value for `kLast`.