### PR TITLE
chore(ci): fix SDK publishing with removal of conflicting SDK

### DIFF
--- a/sdks/uniswapx-sdk/integration/package.json
+++ b/sdks/uniswapx-sdk/integration/package.json
@@ -30,7 +30,7 @@
     "@ethersproject/bytes": "^5.7.0",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.2",
-    "@uniswap/sdk-core": "^5.0.0",
+    "@uniswap/sdk-core": "^7.5.0",
     "dotenv": "^16.0.3",
     "ethers": "^5.7.0",
     "typechain": "^8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4539,23 +4539,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@uniswap/sdk-core@npm:^5.0.0":
-  version: 5.9.0
-  resolution: "@uniswap/sdk-core@npm:5.9.0"
-  dependencies:
-    "@ethersproject/address": ^5.0.2
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/keccak256": 5.7.0
-    "@ethersproject/strings": 5.7.0
-    big.js: ^5.2.2
-    decimal.js-light: ^2.5.0
-    jsbi: ^3.1.4
-    tiny-invariant: ^1.1.0
-    toformat: ^2.0.0
-  checksum: 2bb52a473053f50da68254a9521f907fd34c3eb1c67cda9c0cbe1302da245fe5378a31afdad281a20618ec7f4b9be934c3badf8704a9ab2ae5296f90ae4725a8
-  languageName: node
-  linkType: hard
-
 "@uniswap/sdk-core@npm:^7.5.0":
   version: 7.5.0
   resolution: "@uniswap/sdk-core@npm:7.5.0"
@@ -17609,7 +17592,7 @@ __metadata:
     "@types/chai": ^4.3.3
     "@types/mocha": ^9.1.1
     "@types/node": ^18.7.16
-    "@uniswap/sdk-core": ^5.0.0
+    "@uniswap/sdk-core": ^7.5.0
     chai: ^4.3.6
     dotenv: ^16.0.3
     ethers: ^5.7.0


### PR DESCRIPTION
## Description

https://github.com/Uniswap/sdks/pull/275 bumped sdk-core usage within uniswap-x, but not within the `uniswapx-sdk/integration/package.json`. This somehow created an issue in the publishing pipeline for the `sdk-core`. By updating the version in the integration tests, this fixes the `sdk-core` publishing issue.

## How Has This Been Tested?

- locally with running the previously broken line in publishing and confirming it no longer breaks

```
cd sdks/sdk-core
npm version 7.6.0 --userconfig /tmp/bcef1050b2108be2517d02cc7a9e81da/.npmrc --no-git-tag-version --allow-same-version
```
