### PR TITLE
fix(uniswapx-sdk): Add missing export

### DIFF
--- a/sdks/uniswapx-sdk/src/utils/index.ts
+++ b/sdks/uniswapx-sdk/src/utils/index.ts
@@ -12,6 +12,7 @@ export * from "./EventWatcher";
 export * from "./multicall";
 export * from "./dutchDecay";
 export * from "./order";
+export * from "./PermissionedTokenValidator";
 
 export function stripHexPrefix(a: string): string {
   if (a.startsWith("0x")) {


### PR DESCRIPTION
## Description

Add missing PermissionedTokenValidator export in utils.