### PR TITLE
Dependency CI fix for 

### DIFF
--- a/sdks/smart-wallet-sdk/package.json
+++ b/sdks/smart-wallet-sdk/package.json
@@ -51,7 +51,7 @@
     "ts-jest": "^25.5.1",
     "ts-node": "^10.9.1",
     "tslib": "^2.3.0",
-    "typescript": "^5.6.2"
+    "typescript": "npm:typescript@^5.6.2"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
ignore the rule where the typescript dependency has to match the typescript version of the other repos

https://github.com/Thinkmill/manypkg?tab=readme-ov-file#ignoring-this-rule
__________________
This pull request includes a small change to the `sdks/smart-wallet-sdk/package.json` file. The change updates the `typescript` dependency to use npm aliasing. 

* [`sdks/smart-wallet-sdk/package.json`](diffhunk://#diff-6c97d321754bade5fb6134807a3992e56311a86f9d28b0ca7d9739e86d2c805cL54-R54): Updated the `typescript` dependency to use npm aliasing (`npm:typescript@^5.6.2`).