### PR TITLE
fix: re-add release scripts

### DIFF
--- a/sdks/router-sdk/package.json
+++ b/sdks/router-sdk/package.json
@@ -21,7 +21,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "test": "jest"
+    "test": "jest",
+    "release": "semantic-release"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",

--- a/sdks/sdk-core/package.json
+++ b/sdks/sdk-core/package.json
@@ -24,7 +24,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "test": "jest"
+    "test": "jest",
+    "release": "semantic-release"
   },
   "dependencies": {
     "@ethersproject/address": "^5.0.2",

--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -24,7 +24,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
-    "test": "jest"
+    "test": "jest",
+    "release": "semantic-release"
   },
   "dependencies": {
     "@ethersproject/address": "^5.0.2",

--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -23,7 +23,8 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint src --ext .ts",
-    "test": "jest"
+    "test": "jest",
+    "release": "semantic-release"
   },
   "exports": {
     ".": {

--- a/sdks/v4-sdk/package.json
+++ b/sdks/v4-sdk/package.json
@@ -23,7 +23,8 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:types": "tsc -p tsconfig.types.json",
     "lint": "eslint src --ext .ts",
-    "test": "jest"
+    "test": "jest",
+    "release": "semantic-release"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## PR Scope

fixes the release scripts for v2, v3, v4 and sdk-core

## Description

recent changes to the build processes in these SDKs accidentally removed the yarn script for running semantic release. this adds it back for the listed SDKs

## How Has This Been Tested?

test by looking and verifying it releases when merged

## Are there any breaking changes?

no

