### PR TITLE
fix(universal-router-sdk): export Permit2Permit

### DIFF
--- a/sdks/universal-router-sdk/src/index.ts
+++ b/sdks/universal-router-sdk/src/index.ts
@@ -13,4 +13,4 @@ export {
 } from './utils/constants'
 export { CommandParser, GenericCommandParser } from './utils/commandParser'
 export type { UniversalRouterCommand, UniversalRouterCall, Param, CommandsDefinition } from './utils/commandParser'
-export { Permit2Permit } from './utils/inputTokens'
+export type { Permit2Permit } from './utils/inputTokens'

--- a/sdks/universal-router-sdk/src/index.ts
+++ b/sdks/universal-router-sdk/src/index.ts
@@ -13,3 +13,4 @@ export {
 } from './utils/constants'
 export { CommandParser, GenericCommandParser } from './utils/commandParser'
 export type { UniversalRouterCommand, UniversalRouterCall, Param, CommandsDefinition } from './utils/commandParser'
+export { Permit2Permit } from './utils/inputTokens'


### PR DESCRIPTION
## Description

need to export [Permit2Permit](https://github.com/Uniswap/sdks/blob/35a3e02f4ba39b31c6ac421fca9a83bc7bf15ed8/sdks/universal-router-sdk/src/utils/inputTokens.ts#L9) as index from ur-sdk, because of SOR [dist import style](https://github.com/Uniswap/smart-order-router/blob/e635eba43055265b1ae3c7450f79729588b5399a/test/integ/routers/alpha-router/alpha-router.integration.test.ts#L29).

## How Has This Been Tested?

will test in SOR

## Are there any breaking changes?

No

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_
