### PR TITLE
feat(UniswapX): Add expected amounts to DutchV3

### DIFF
--- a/sdks/uniswapx-sdk/src/trade/V3DutchOrderTrade.test.ts
+++ b/sdks/uniswapx-sdk/src/trade/V3DutchOrderTrade.test.ts
@@ -215,7 +215,7 @@ describe("V3DutchOrderTrade", () => {
 	describe("Expected amounts", () => {
 		const expectedAmounts = {
 			expectedAmountIn: "800",
-			expectedAmountOut: "900"
+			expectedAmountOut: "900",
 		};
 
 		const tradeWithExpectedAmounts = new V3DutchOrderTrade<Currency, Currency, TradeType>({
@@ -223,7 +223,7 @@ describe("V3DutchOrderTrade", () => {
 			currenciesOut: [DAI],
 			orderInfo,
 			tradeType: TradeType.EXACT_INPUT,
-			expectedAmounts
+			expectedAmounts,
 		});
 
 		it("uses expectedAmountIn when provided", () => {
@@ -252,7 +252,7 @@ describe("V3DutchOrderTrade", () => {
 				currencyIn: USDC,
 				currenciesOut: [DAI],
 				orderInfo,
-				tradeType: TradeType.EXACT_INPUT
+				tradeType: TradeType.EXACT_INPUT,
 			});
 
 			// Using private method through any to test error case
@@ -266,7 +266,7 @@ describe("V3DutchOrderTrade", () => {
 				currencyIn: USDC,
 				currenciesOut: [DAI],
 				orderInfo,
-				tradeType: TradeType.EXACT_INPUT
+				tradeType: TradeType.EXACT_INPUT,
 			});
 
 			// Using private method through any to test error case

--- a/sdks/uniswapx-sdk/src/trade/V3DutchOrderTrade.test.ts
+++ b/sdks/uniswapx-sdk/src/trade/V3DutchOrderTrade.test.ts
@@ -211,4 +211,68 @@ describe("V3DutchOrderTrade", () => {
 			expect(ethOutputTrade.outputAmount.currency).toEqual(Ether.onChain(1));
 		});
 	});
+
+	describe("Expected amounts", () => {
+		const expectedAmounts = {
+			expectedAmountIn: "800",
+			expectedAmountOut: "900"
+		};
+
+		const tradeWithExpectedAmounts = new V3DutchOrderTrade<Currency, Currency, TradeType>({
+			currencyIn: USDC,
+			currenciesOut: [DAI],
+			orderInfo,
+			tradeType: TradeType.EXACT_INPUT,
+			expectedAmounts
+		});
+
+		it("uses expectedAmountIn when provided", () => {
+			expect(tradeWithExpectedAmounts.inputAmount.quotient.toString()).toEqual(
+				expectedAmounts.expectedAmountIn
+			);
+		});
+
+		it("uses expectedAmountOut when provided", () => {
+			expect(tradeWithExpectedAmounts.outputAmount.quotient.toString()).toEqual(
+				expectedAmounts.expectedAmountOut
+			);
+		});
+
+		it("falls back to order amounts when expectedAmounts is not provided", () => {
+			expect(trade.inputAmount.quotient.toString()).toEqual(
+				orderInfo.input.startAmount.toString()
+			);
+			expect(trade.outputAmount.quotient.toString()).toEqual(
+				NON_FEE_OUTPUT_AMOUNT.toString()
+			);
+		});
+
+		it("throws when accessing expectedAmountIn that wasn't provided", () => {
+			const tradeWithoutExpected = new V3DutchOrderTrade<Currency, Currency, TradeType>({
+				currencyIn: USDC,
+				currenciesOut: [DAI],
+				orderInfo,
+				tradeType: TradeType.EXACT_INPUT
+			});
+
+			// Using private method through any to test error case
+			expect(() => {
+				(tradeWithoutExpected as any).getExpectedAmountIn();
+			}).toThrow("expectedAmountIn not set");
+		});
+
+		it("throws when accessing expectedAmountOut that wasn't provided", () => {
+			const tradeWithoutExpected = new V3DutchOrderTrade<Currency, Currency, TradeType>({
+				currencyIn: USDC,
+				currenciesOut: [DAI],
+				orderInfo,
+				tradeType: TradeType.EXACT_INPUT
+			});
+
+			// Using private method through any to test error case
+			expect(() => {
+				(tradeWithoutExpected as any).getExpectedAmountOut();
+			}).toThrow("expectedAmountOut not set");
+		});
+	});
 });


### PR DESCRIPTION
## PR Scope

## Description

Similar to Priority Trades, allow caller to pass in the expected amounts to the trade to override the amount in/out.

## How Has This Been Tested?

Unit tests

## Are there any breaking changes?

No.