### PR TITLE
fix: encoding issue with ABI parameters

### DIFF
--- a/sdks/smart-wallet-sdk/src/utils/callPlanner.ts
+++ b/sdks/smart-wallet-sdk/src/utils/callPlanner.ts
@@ -15,7 +15,7 @@ export const CALL_ABI_PARAMS = [
 ] as const
 
 /**
- * CallPlanner is used to encode a series Calls
+ * CallPlanner is used to encode a series of Calls
  */
 export class CallPlanner {
   calls: Call[]
@@ -50,8 +50,13 @@ export class CallPlanner {
       throw new Error("No calls to encode")
     }
 
-    
-    return encodeAbiParameters(CALL_ABI_PARAMS, [this.calls])
+    return encodeAbiParameters(CALL_ABI_PARAMS, [
+      this.calls.map(call => [
+        call.to,
+        call.value.toString(),
+        call.data
+      ])
+    ])
   }
 
   /**


### PR DESCRIPTION
## Description

II’ve corrected an issue with the data being passed to `encodeAbiParameters`. Previously, we were directly passing `this.calls`, but now each `Call` object is mapped to an array of `[to, value, data]`, which aligns with the `tuple[]` format expected by the ABI.

Additionally, I’ve ensured that the `value` is properly converted to a string before encoding, as the ABI encoder expects a string representation for numbers like `uint256`.

This should resolve any issues related to the encoding of ABI parameters and improve compatibility with the expected format.

## (Optional) Feedback Focus

**Reasons why I am confident in the fixes:**
- **Encoding of the Call[] array**: The ABI encoder expects an array of tuples for `tuple[]`. We need to ensure that each element is an array of three values (in your case: `to`, `value`, and `data`).
  
- **Converting bigint to string**: Typically, ABI expects a string representation for numeric values of type `uint256`. Converting `value` to a string ensures that it will be correctly encoded.