### PR TITLE
fix(smart-walet-sdk): V1 launch addresses and README

### DIFF
--- a/sdks/smart-wallet-sdk/README.md
+++ b/sdks/smart-wallet-sdk/README.md
@@ -22,19 +22,13 @@ Below is a table of the most recent contract deployment addresses across various
 
 | Network | Address | Commit Hash | Version |
 |---------|---------|------------|---------|
-| Mainnet | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Unichain | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Base | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Polygon | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Arbitrum | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| BNB Chain | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Blast | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| World | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Zora | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Avalanche | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Soneium | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Unichain Sepolia | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
-| Sepolia | 0x458f5a9f47A01beA5d7A32662660559D9eD3312c | d9b1dacc3a818eaf3d22534aa38ba72b2c56b6f1 | v0.3.0-audit.2 |
+| Mainnet | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
+| Unichain | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
+| Base | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
+| Optimism | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
+| BNB Chain | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
+| Unichain Sepolia | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
+| Sepolia | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
 
 ## Documentation
 

--- a/sdks/smart-wallet-sdk/src/constants.ts
+++ b/sdks/smart-wallet-sdk/src/constants.ts
@@ -27,11 +27,7 @@ export enum SupportedChainIds {
   SEPOLIA = ChainId.SEPOLIA,
   BASE = ChainId.BASE,
   OPTIMISM = ChainId.OPTIMISM,
-  ARBITRUM_ONE = ChainId.ARBITRUM_ONE,
-  POLYGON = ChainId.POLYGON,
   BNB = ChainId.BNB,
-  SONEIUM = ChainId.SONEIUM,
-  ZORA = ChainId.ZORA,
 }
 
 /**
@@ -40,8 +36,8 @@ export enum SupportedChainIds {
  */
 export enum SmartWalletVersion {
   LATEST = 'latest',
-  v1_0_0_staging = 'v1.0.0-staging',
-  v0_3_0_audit_2 = 'v0.3.0-audit.2'
+  v1_0_0 = 'v1.0.0',
+  v1_0_0_staging = 'v1.0.0-staging'
 }
 
 // All smart wallet versions for a given chain id are optional except for the latest version
@@ -52,58 +48,40 @@ type SmartWalletVersionMap = Partial<{ [version in SmartWalletVersion]: `0x${str
  */
 export const SMART_WALLET_VERSIONS: { [chainId in SupportedChainIds]: SmartWalletVersionMap } = {
   [SupportedChainIds.MAINNET]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
+    [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+    [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v0_3_0_audit_2]: '0x458f5a9f47A01beA5d7A32662660559D9eD3312c',
   },
   [SupportedChainIds.UNICHAIN]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
+    [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+    [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v0_3_0_audit_2]: '0x458f5a9f47A01beA5d7A32662660559D9eD3312c',
   },
   [SupportedChainIds.BASE]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
+    [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+    [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v0_3_0_audit_2]: '0x458f5a9f47A01beA5d7A32662660559D9eD3312c',
   },
   [SupportedChainIds.OPTIMISM]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
+    [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+    [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
   },
   [SupportedChainIds.BNB]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
+    [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+    [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v0_3_0_audit_2]: '0x458f5a9f47A01beA5d7A32662660559D9eD3312c',
-  },
-  [SupportedChainIds.ARBITRUM_ONE]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v0_3_0_audit_2]: '0x458f5a9f47A01beA5d7A32662660559D9eD3312c',
-  },
-  [SupportedChainIds.POLYGON]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v0_3_0_audit_2]: '0x458f5a9f47A01beA5d7A32662660559D9eD3312c',
-  },
-  [SupportedChainIds.ZORA]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v0_3_0_audit_2]: '0x458f5a9f47A01beA5d7A32662660559D9eD3312c',
   },
   [SupportedChainIds.UNICHAIN_SEPOLIA]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
+    [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+    [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v0_3_0_audit_2]: '0x458f5a9f47A01beA5d7A32662660559D9eD3312c',
   },
   [SupportedChainIds.SEPOLIA]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
+    [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+    [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v0_3_0_audit_2]: '0x458f5a9f47A01beA5d7A32662660559D9eD3312c',
-  },
-  [SupportedChainIds.SONEIUM]: {
-    [SmartWalletVersion.LATEST]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-    [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5'
-  },
+  }
 }
 
 /**


### PR DESCRIPTION
Adds newest deploys (v1_0_0) for the following chains:
```
export enum SupportedChainIds {
  MAINNET = ChainId.MAINNET,
  UNICHAIN = ChainId.UNICHAIN,
  UNICHAIN_SEPOLIA = ChainId.UNICHAIN_SEPOLIA,
  SEPOLIA = ChainId.SEPOLIA,
  BASE = ChainId.BASE,
  OPTIMISM = ChainId.OPTIMISM,
  BNB = ChainId.BNB,
}
```

All other chains are not supported for the v1 launch and removed.