### PR TITLE
fix(smart-wallet-sdk): harden `createExecute` against prototype pollution attacks

### DIFF
--- a/sdks/smart-wallet-sdk/src/constants.ts
+++ b/sdks/smart-wallet-sdk/src/constants.ts
@@ -1,12 +1,12 @@
 import { ChainId } from '@uniswap/sdk-core'
 
 // https://eips.ethereum.org/EIPS/eip-7702
-export const DELEGATION_MAGIC_PREFIX = '0xef0100';
+export const DELEGATION_MAGIC_PREFIX = '0xef0100'
 
 /**
  * The target address for self-calls is address(0)
  */
-export const SELF_CALL_TARGET = "0x0000000000000000000000000000000000000000"
+export const SELF_CALL_TARGET = '0x0000000000000000000000000000000000000000'
 
 /**
  * Call types for smart wallet calls
@@ -14,7 +14,7 @@ export const SELF_CALL_TARGET = "0x0000000000000000000000000000000000000000"
  */
 export enum ModeType {
   BATCHED_CALL = '0x0100000000000000000000000000000000000000000000000000000000000000',
-  BATCHED_CALL_CAN_REVERT = '0x0101000000000000000000000000000000000000000000000000000000000000'
+  BATCHED_CALL_CAN_REVERT = '0x0101000000000000000000000000000000000000000000000000000000000000',
 }
 
 /**
@@ -37,11 +37,13 @@ export enum SupportedChainIds {
 export enum SmartWalletVersion {
   LATEST = 'latest',
   v1_0_0 = 'v1.0.0',
-  v1_0_0_staging = 'v1.0.0-staging'
+  v1_0_0_staging = 'v1.0.0-staging',
 }
 
 // All smart wallet versions for a given chain id are optional except for the latest version
-type SmartWalletVersionMap = Partial<{ [version in SmartWalletVersion]: `0x${string}` }> & { [SmartWalletVersion.LATEST]: `0x${string}` }
+type SmartWalletVersionMap = Partial<{ [version in SmartWalletVersion]: `0x${string}` }> & {
+  [SmartWalletVersion.LATEST]: `0x${string}`
+}
 
 /**
  * Smart wallet versions for supported chains
@@ -81,7 +83,7 @@ export const SMART_WALLET_VERSIONS: { [chainId in SupportedChainIds]: SmartWalle
     [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
-  }
+  },
 }
 
 /**
@@ -89,12 +91,17 @@ export const SMART_WALLET_VERSIONS: { [chainId in SupportedChainIds]: SmartWalle
  * @dev Used to get the latest version of the smart wallet
  *      See README for detailed deployment addresses along with the commit hash
  */
-export const SMART_WALLET_ADDRESSES = Object.fromEntries(
-  Object.entries(SMART_WALLET_VERSIONS).map(([chainId, versions]) => [
+// Build address map with a null prototype to avoid inherited property lookups
+export const SMART_WALLET_ADDRESSES = (() => {
+  const entries = Object.entries(SMART_WALLET_VERSIONS).map(([chainId, versions]) => [
     chainId,
-    versions[SmartWalletVersion.LATEST]
+    versions[SmartWalletVersion.LATEST],
   ])
-)
+  const map = Object.fromEntries(entries) as Record<string | number, `0x${string}`>
+  // Explicitly remove prototype to prevent access via __proto__/constructor, etc.
+  Object.setPrototypeOf(map, null)
+  return map
+})()
 
 /**
  * Get all historical smart wallet versions for a given chain id

--- a/sdks/smart-wallet-sdk/src/constants.ts
+++ b/sdks/smart-wallet-sdk/src/constants.ts
@@ -90,8 +90,8 @@ export const SMART_WALLET_VERSIONS: { [chainId in SupportedChainIds]: SmartWalle
  * Mapping of chainId to Smart Wallet contract addresses
  * @dev Used to get the latest version of the smart wallet
  *      See README for detailed deployment addresses along with the commit hash
+ * @deprecated Use getSmartWalletAddress() instead of indexing this map directly.
  */
-// Build address map with a null prototype to avoid inherited property lookups
 export const SMART_WALLET_ADDRESSES = (() => {
   const entries = Object.entries(SMART_WALLET_VERSIONS).map(([chainId, versions]) => [
     chainId,
@@ -108,4 +108,17 @@ export const SMART_WALLET_ADDRESSES = (() => {
  */
 export const getAllSmartWalletVersions = (chainId: SupportedChainIds) => {
   return Object.values(SMART_WALLET_VERSIONS[chainId])
+}
+
+/**
+ * Get the latest Smart Wallet address for a given chain id.
+ * Normalizes string ids to numbers and guards against prototype pollution.
+ */
+export function getSmartWalletAddress(chainIdLike: number | string | ChainId): `0x${string}` {
+  const normalized = typeof chainIdLike === 'string' ? Number(chainIdLike) : chainIdLike
+  const isValid = typeof normalized === 'number' && Number.isFinite(normalized) && Number.isInteger(normalized)
+  if (!isValid || !Object.prototype.hasOwnProperty.call(SMART_WALLET_ADDRESSES, normalized)) {
+    throw new Error(`Smart wallet not found for chainId: ${chainIdLike}`)
+  }
+  return (SMART_WALLET_ADDRESSES as Record<number, `0x${string}`>)[normalized]
 }

--- a/sdks/smart-wallet-sdk/src/smartWallet.test.ts
+++ b/sdks/smart-wallet-sdk/src/smartWallet.test.ts
@@ -1,13 +1,13 @@
 import { ChainId } from '@uniswap/sdk-core'
-import { decodeFunctionData } from 'viem';
+import { decodeFunctionData } from 'viem'
 
-import abi from "../abis/MinimalDelegationEntry.json"
+import abi from '../abis/MinimalDelegationEntry.json'
 
-import { ModeType, SMART_WALLET_ADDRESSES } from './constants';
+import { ModeType, SMART_WALLET_ADDRESSES } from './constants'
 import { SmartWallet } from './smartWallet'
 import { BatchedCall, Call } from './types'
 
-const EXECUTE_SELECTOR = "0xe9ae5c53" as `0x${string}`
+const EXECUTE_SELECTOR = '0xe9ae5c53' as `0x${string}`
 
 describe('SmartWallet', () => {
   describe('encodeBatchedCall', () => {
@@ -17,26 +17,26 @@ describe('SmartWallet', () => {
           to: '0x1111111111111111111111111111111111111111',
           data: '0x1234',
           value: 0n,
-          chainId: ChainId.SEPOLIA
+          chainId: ChainId.SEPOLIA,
         },
         {
           to: '0x2222222222222222222222222222222222222222',
           data: '0x5678',
           value: 1n,
-          chainId: ChainId.SEPOLIA
-        }
+          chainId: ChainId.SEPOLIA,
+        },
       ]
 
       const result = SmartWallet.encodeBatchedCall(calls, { revertOnFailure: false })
       // decode the calldata
       const decoded = decodeFunctionData({
         abi,
-        data: result.calldata
+        data: result.calldata,
       })
       expect(decoded).toBeDefined()
       expect(decoded.functionName).toBe('execute')
       expect(decoded.args).toBeDefined()
-      if(decoded.args) {
+      if (decoded.args) {
         expect(decoded.args.length).toBe(1)
         expect(decoded.args[0]).toBeDefined()
         expect((decoded.args[0] as BatchedCall).calls).toBeDefined()
@@ -52,13 +52,13 @@ describe('SmartWallet', () => {
         {
           to: '0x1111111111111111111111111111111111111111',
           data: '0x1234',
-          value: 0n
+          value: 0n,
         },
         {
           to: '0x2222222222222222222222222222222222222222',
           data: '0x5678',
-          value: 1n
-        }
+          value: 1n,
+        },
       ]
 
       const result = SmartWallet.encodeERC7821BatchedCall(calls)
@@ -72,10 +72,10 @@ describe('SmartWallet', () => {
         {
           to: '0x1111111111111111111111111111111111111111',
           data: '0x1234',
-          value: 0n
-        }
+          value: 0n,
+        },
       ]
-      
+
       const result = SmartWallet.encodeERC7821BatchedCall(calls, { revertOnFailure: true })
       expect(result).toBeDefined()
       expect(result.calldata).toBeDefined()
@@ -89,8 +89,8 @@ describe('SmartWallet', () => {
         {
           to: '0x1111111111111111111111111111111111111111',
           data: '0x1234',
-          value: 0n
-        }
+          value: 0n,
+        },
       ]
       expect(() => SmartWallet.encodeERC7821BatchedCall(calls)).toThrow()
 
@@ -102,23 +102,64 @@ describe('SmartWallet', () => {
     it('creates an execute call for specific chain', () => {
       const methodParams = {
         calldata: EXECUTE_SELECTOR,
-        value: 0n
+        value: 0n,
       }
-      
+
       const call = SmartWallet.createExecute(methodParams, ChainId.SEPOLIA)
-      
+
       // Verify the result
       expect(call).toBeDefined()
       expect(call.to).toBe(SMART_WALLET_ADDRESSES[ChainId.SEPOLIA])
       expect(call.data).toBe(EXECUTE_SELECTOR)
       expect(call.value).toBe(0n)
     })
+
+    it('throws when chainId is a dangerous string like __proto__', () => {
+      const methodParams = {
+        calldata: EXECUTE_SELECTOR,
+        value: 0n,
+      }
+      expect(() => SmartWallet.createExecute(methodParams, '__proto__' as unknown as ChainId)).toThrow(
+        /Smart wallet not found for chainId: __proto__/i
+      )
+    })
+
+    it('throws when chainId is the string "constructor"', () => {
+      const methodParams = {
+        calldata: EXECUTE_SELECTOR,
+        value: 0n,
+      }
+      expect(() => SmartWallet.createExecute(methodParams, 'constructor' as unknown as ChainId)).toThrow(
+        /Smart wallet not found for chainId: constructor/i
+      )
+    })
+
+    it('throws for non-numeric random string chainId', () => {
+      const methodParams = {
+        calldata: EXECUTE_SELECTOR,
+        value: 0n,
+      }
+      expect(() => SmartWallet.createExecute(methodParams, 'forty-two' as unknown as ChainId)).toThrow(
+        /Smart wallet not found for chainId: forty-two/i
+      )
+    })
+
+    it('throws for unsupported numeric chainId', () => {
+      const methodParams = {
+        calldata: EXECUTE_SELECTOR,
+        value: 0n,
+      }
+      // 1337 is intentionally not present in SMART_WALLET_ADDRESSES
+      expect(() => SmartWallet.createExecute(methodParams, 1337 as ChainId)).toThrow(
+        /Smart wallet not found for chainId: 1337/i
+      )
+    })
   })
 
   describe('getModeFromOptions', () => {
-    for(const revertOnFailure of [true, false]) {
+    for (const revertOnFailure of [true, false]) {
       it(`returns the correct mode type for revertOnFailure: ${revertOnFailure}`, () => {
-        if(revertOnFailure) {
+        if (revertOnFailure) {
           expect(SmartWallet.getModeFromOptions({ revertOnFailure })).toBe(ModeType.BATCHED_CALL)
         } else {
           expect(SmartWallet.getModeFromOptions({ revertOnFailure })).toBe(ModeType.BATCHED_CALL_CAN_REVERT)

--- a/sdks/smart-wallet-sdk/src/smartWallet.ts
+++ b/sdks/smart-wallet-sdk/src/smartWallet.ts
@@ -3,7 +3,7 @@ import { encodeFunctionData } from 'viem'
 
 import abi from '../abis/MinimalDelegationEntry.json'
 
-import { ModeType, SMART_WALLET_ADDRESSES } from './constants'
+import { ModeType, getSmartWalletAddress } from './constants'
 import { Call, MethodParameters, ExecuteOptions } from './types'
 import { CallPlanner } from './utils'
 import { BatchedCallPlanner } from './utils/batchedCallPlanner'
@@ -61,16 +61,7 @@ export class SmartWallet {
    * @returns The call to execute
    */
   public static createExecute(methodParameters: MethodParameters, chainId: ChainId): Call {
-    // Normalize and validate chainId prior to lookup to avoid prototype pollution and inherited keys
-    const normalizedChainId = typeof (chainId as unknown) === 'string' ? Number(chainId) : chainId
-    const isValidNumericChainId =
-      typeof normalizedChainId === 'number' && Number.isFinite(normalizedChainId) && Number.isInteger(normalizedChainId)
-
-    if (!isValidNumericChainId || !Object.prototype.hasOwnProperty.call(SMART_WALLET_ADDRESSES, normalizedChainId)) {
-      throw new Error(`Smart wallet not found for chainId: ${chainId}`)
-    }
-
-    const address = (SMART_WALLET_ADDRESSES as Record<number, `0x${string}`>)[normalizedChainId as number]
+    const address = getSmartWalletAddress(chainId)
     return {
       to: address,
       data: methodParameters.calldata,

--- a/sdks/smart-wallet-sdk/src/smartWallet.ts
+++ b/sdks/smart-wallet-sdk/src/smartWallet.ts
@@ -21,15 +21,15 @@ export class SmartWallet {
   public static encodeBatchedCall(calls: Call[], options: ExecuteOptions = {}): MethodParameters {
     const planner = new CallPlanner(calls)
     const batchedCallPlanner = new BatchedCallPlanner(planner, options.revertOnFailure)
-    
+
     const encoded = encodeFunctionData({
       abi,
       functionName: '0x99e1d016', // execute(((address,uint256,bytes)[],bool))
-      args: [batchedCallPlanner.toBatchedCall()]
+      args: [batchedCallPlanner.toBatchedCall()],
     })
     return {
       calldata: encoded,
-      value: planner.value
+      value: planner.value,
     }
   }
 
@@ -39,17 +39,17 @@ export class SmartWallet {
    */
   public static encodeERC7821BatchedCall(calls: Call[], options: ExecuteOptions = {}): MethodParameters {
     const mode = this.getModeFromOptions(options)
-    if(mode != ModeType.BATCHED_CALL && mode != ModeType.BATCHED_CALL_CAN_REVERT) {
+    if (mode != ModeType.BATCHED_CALL && mode != ModeType.BATCHED_CALL_CAN_REVERT) {
       throw new Error(`Invalid mode: ${mode}`)
     }
 
     const planner = new CallPlanner(calls)
-    
+
     const executionData = planner.encode()
     const encoded = this._encodeERC7821Execute(mode, executionData)
     return {
       calldata: encoded,
-      value: planner.value
+      value: planner.value,
     }
   }
 
@@ -60,15 +60,21 @@ export class SmartWallet {
    * @param chainId The chain ID for the smart wallet
    * @returns The call to execute
    */
-  public static createExecute(methodParameters: MethodParameters, chainId: ChainId ): Call {
-    const address = SMART_WALLET_ADDRESSES[chainId]
-    if(!address) {
+  public static createExecute(methodParameters: MethodParameters, chainId: ChainId): Call {
+    // Normalize and validate chainId prior to lookup to avoid prototype pollution and inherited keys
+    const normalizedChainId = typeof (chainId as unknown) === 'string' ? Number(chainId) : chainId
+    const isValidNumericChainId =
+      typeof normalizedChainId === 'number' && Number.isFinite(normalizedChainId) && Number.isInteger(normalizedChainId)
+
+    if (!isValidNumericChainId || !Object.prototype.hasOwnProperty.call(SMART_WALLET_ADDRESSES, normalizedChainId)) {
       throw new Error(`Smart wallet not found for chainId: ${chainId}`)
     }
+
+    const address = (SMART_WALLET_ADDRESSES as Record<number, `0x${string}`>)[normalizedChainId as number]
     return {
       to: address,
       data: methodParameters.calldata,
-      value: methodParameters.value
+      value: methodParameters.value,
     }
   }
 
@@ -76,23 +82,20 @@ export class SmartWallet {
    * Get the mode type from the options
    */
   public static getModeFromOptions(options: ExecuteOptions): ModeType {
-    if(options.revertOnFailure) {
-      return ModeType.BATCHED_CALL;
+    if (options.revertOnFailure) {
+      return ModeType.BATCHED_CALL
     }
 
     return ModeType.BATCHED_CALL_CAN_REVERT
   }
 
   /** Internal methods */
-  
+
   protected static _encodeERC7821Execute(mode: ModeType, data: `0x${string}`): `0x${string}` {
     return encodeFunctionData({
       abi,
       functionName: '0xe9ae5c53', // execute(bytes32,bytes)
-      args: [
-        mode,
-        data
-      ]
+      args: [mode, data],
     })
   }
 }


### PR DESCRIPTION
## Description

Hardened `SmartWallet.createExecute` against prototype pollution and invalid inputs; hardened the address map; added tests. This addresses a reported issue where passing inherited object keys like `"__proto__"` or `"constructor"` as `chainId` would incorrectly pass the existing check, producing malformed `to` addresses. Reported via [Cantina Finding #471](https://cantina.xyz/code/f9df94db-c7b1-434b-bb06-d1360abdd1be/findings?finding=471)

### Fix Details
- **Input validation** (`src/smart-wallet-sdk/src/smartWallet.ts`)
  - Normalize `chainId` (convert string to number when possible).
  - Validate it is a finite integer and a direct key of `SMART_WALLET_ADDRESSES` using `Object.prototype.hasOwnProperty.call`.
  - If invalid or absent, throw: `Smart wallet not found for chainId: ${chainId}`.
- **Map hardening** (`src/smart-wallet-sdk/src/constants.ts`)
  - Build `SMART_WALLET_ADDRESSES` with a null prototype via `Object.setPrototypeOf(map, null)` to block inherited property access (e.g., `__proto__`, `constructor`). Mark deprecated in favor of `getSmartWalletAddress`.
  - Export new `getSmartWalletAddress(chainIdLike)` which validates the provided chain id and either returns a valid address or throws.
- **Tests** (`src/smart-wallet-sdk/src/smartWallet.test.ts`)
  - Valid path: ensures `createExecute` returns expected `to`, `data`, `value` for a real numeric `ChainId`.
  - Invalid inputs: asserts throws for `"__proto__"`, `"constructor"`, arbitrary non-numeric strings (e.g., `"forty-two"`), and unsupported numeric IDs (e.g., `1337`).

### Security impact
- **Prevents prototype pollution vector** where inherited keys could be treated as valid `chainId` values, leading to malformed `to` addresses.

## How Has This Been Tested?

- New tests validate both happy path and error scenarios for `createExecute`.
- All package tests, including new additions, are green.

## Are there any breaking changes?

- No API changes. Behavior now throws for invalid or unsupported `chainId` values that previously might have slipped through due to inherited property lookups.