### PR TITLE
fix(v4-sdk): Update next tick calculation with tick spacing

### DIFF
--- a/sdks/v4-sdk/src/entities/pool.ts
+++ b/sdks/v4-sdk/src/entities/pool.ts
@@ -117,7 +117,7 @@ export class Pool {
       invariant(Number(hooks) > 0, 'Dynamic fee pool requires a hook')
     }
     const tickCurrentSqrtRatioX96 = TickMath.getSqrtRatioAtTick(tickCurrent)
-    const nextTickSqrtRatioX96 = TickMath.getSqrtRatioAtTick(tickCurrent + 1)
+    const nextTickSqrtRatioX96 = TickMath.getSqrtRatioAtTick(tickCurrent + tickSpacing)
     invariant(
       JSBI.greaterThanOrEqual(JSBI.BigInt(sqrtRatioX96), tickCurrentSqrtRatioX96) &&
         JSBI.lessThanOrEqual(JSBI.BigInt(sqrtRatioX96), nextTickSqrtRatioX96),


### PR DESCRIPTION
## PR Scope

fix(v4-sdk): Update next tick calculation with tick spacing

## Description

Pool constructor checks price bounds between currentTick and currentTick + 1.  However, it should use tick spacing instead of defaulting to 1.

## How Has This Been Tested?

Manually tested via v4-sdk in typescript.

## Are there any breaking changes?

No breaking changes. This change should make the bounds check more lenient.