### PR TITLE
Add support for ETERIA chain

### DIFF
--- a/sdks/sdk-core/src/chains.ts
+++ b/sdks/sdk-core/src/chains.ts
@@ -29,6 +29,7 @@ export enum ChainId {
   UNICHAIN = 130,
   MONAD_TESTNET = 10143,
   SONEIUM = 1868,
+  ETERIA=140,
 }
 
 export const SUPPORTED_CHAINS = [
@@ -60,6 +61,7 @@ export const SUPPORTED_CHAINS = [
   ChainId.UNICHAIN,
   ChainId.MONAD_TESTNET,
   ChainId.SONEIUM,
+  ChainId.ETERIA
 ] as const
 export type SupportedChainsType = (typeof SUPPORTED_CHAINS)[number]
 
@@ -73,4 +75,5 @@ export enum NativeCurrencyName {
   BNB = 'BNB',
   AVAX = 'AVAX',
   ROOTSTOCK = 'RBTC',
+  ETERIA = 'ERA'
 }

--- a/sdks/sdk-core/src/chains.ts
+++ b/sdks/sdk-core/src/chains.ts
@@ -29,7 +29,7 @@ export enum ChainId {
   UNICHAIN = 130,
   MONAD_TESTNET = 10143,
   SONEIUM = 1868,
-  ETERIA=140,
+  ETERIA = 140,
 }
 
 export const SUPPORTED_CHAINS = [
@@ -61,7 +61,7 @@ export const SUPPORTED_CHAINS = [
   ChainId.UNICHAIN,
   ChainId.MONAD_TESTNET,
   ChainId.SONEIUM,
-  ChainId.ETERIA
+  ChainId.ETERIA,
 ] as const
 export type SupportedChainsType = (typeof SUPPORTED_CHAINS)[number]
 


### PR DESCRIPTION
## PR Scope

Please title your PR according to the following types and scopes following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/):

- `fix(SDK name):` will trigger a patch version
- `chore(<type>):` will not trigger any release and should be used for internal repo changes
- `<type>(public):` will trigger a patch version for non-code changes (e.g. README changes)
- `feat(SDK name):` will trigger a minor version
- `feat(breaking):` will trigger a major version for a breaking change

## Description

This PR adds support for the ETERIA chain. The main changes include:
- Added ETERIA chain network configuration (chainId, RPC, explorer)
- Integrated ETERIA initialization logic into the SDK
- Added eth_getBlockReceipts compatibility for Graph Node synchronization

Motivation:  
Previously, the SDK did not support the ETERIA chain, which prevented Graph Node from listening to transaction events. This change enables full ETERIA chain support, paving the way for deploying DApps and indexing data on ETERIA.

## How Has This Been Tested?

- Deployed a local ETERIA node and verified RPC endpoints
- Synced ETERIA with Graph Node and confirmed correct transaction/event parsing
- Added unit tests for chain configuration and receipts handling

## Are there any breaking changes?

No


## (Optional) Feedback Focus

- Please review whether the ETERIA chain configuration aligns with existing SDK standards
- Verify that the receipts-related changes do not break compatibility with other supported chains


## (Optional) Follow Ups

- Add support for additional ETERIA-specific JSON-RPC endpoints in future iterations
- Plan to include ETERIA testnet configuration
