### PR TITLE
feat(config): add supply chain security controls

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,12 @@
+# Bun configuration file
+
+[install]
+# Save exact versions
+save = "exact"
+
+# Supply chain protection: reject package versions published less than 3 days ago
+# To bypass for specific packages: minimumReleaseAgeExcludes = ["package-name"]
+minimumReleaseAge = 259200
+
+# Pin the default registry explicitly to prevent registry confusion attacks
+registry = "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "packageManager": "bun@1.3.10",
   "private": true,
+  "trustedDependencies": [],
   "scripts": {
     "g:check:deps:mismatch": "check-dependency-version-consistency --ignore-dep @typescript-eslint/parser --ignore-dep typescript",
     "g:build": "turbo run build",


### PR DESCRIPTION
## Summary

Hardens the sdks monorepo's supply chain security in response to the [axios account takeover](https://github.com/axios/axios/issues/10604) (March 31, 2026). Three layers: quarantine newly-published packages, restrict lifecycle scripts, and pin the npm registry.

Mirrors Uniswap/universe#30558.

## What changed

**`bunfig.toml`** (new file) — two install-time protections:
- `minimumReleaseAge = 259200` rejects package versions published less than 3 days ago
- `registry = "https://registry.npmjs.org"` pins the default registry to prevent dependency confusion

**`package.json`** — explicit `trustedDependencies` allowlist of packages permitted to run lifecycle scripts.

## Test plan

- [ ] `bun install` succeeds with new config
- [ ] `bun pm untrusted` confirms suspicious packages are blocked
- [ ] Legitimate native addons still run via explicit allowlist
- [ ] CI passes with frozen lockfile

## Session context

Supply chain hardening applied across all Bun-based Uniswap repos. The axios attack dropped a cross-platform RAT via a postinstall script in a fake dependency. These controls would have blocked both the malicious versions (age gate) and the payload execution (script allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)