### PR TITLE
feat(ur-sdk): bump universal-router-sdk

### DIFF
--- a/.changeset/proud-terms-deny.md
+++ b/.changeset/proud-terms-deny.md
@@ -1,5 +1,0 @@
----
-"@uniswap/universal-router-sdk": minor
----
-
-Add SwapRouter.encodeSwaps(spec, swapSteps), an alternative entry point for callers that can provide explicit SwapStep[] plans

--- a/sdks/universal-router-sdk/CHANGELOG.md
+++ b/sdks/universal-router-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uniswap/universal-router-sdk
 
+## 5.3.0
+
+### Minor Changes
+
+- e8e7bd5: Add SwapRouter.encodeSwaps(spec, swapSteps), an alternative entry point for callers that can provide explicit SwapStep[] plans
+
 ## 5.2.0
 
 ### Minor Changes

--- a/sdks/universal-router-sdk/package.json
+++ b/sdks/universal-router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/universal-router-sdk",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "sdk for integrating with the Universal Router contracts",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [


### PR DESCRIPTION
## PR Scope


# Releases
## @uniswap/universal-router-sdk@5.3.0

### Minor Changes

-   e8e7bd5: Add SwapRouter.encodeSwaps(spec, swapSteps), an alternative entry point for callers that can provide explicit SwapStep\[] plans