### PR TITLE
feat(sdk-core): add MegaETH support

### DIFF
--- a/.changeset/few-oranges-kneel.md
+++ b/.changeset/few-oranges-kneel.md
@@ -1,0 +1,6 @@
+---
+"@uniswap/sdk-core": minor
+"@uniswap/universal-router-sdk": minor
+---
+
+Add MegaETH chain and Universal Router deployment config

--- a/README.md
+++ b/README.md
@@ -11,27 +11,27 @@ git clone --recurse-submodules https://github.com/Uniswap/sdks.git
 
 # Install
 
-yarn
+bun install
 
 # Build
 
-yarn g:build
+bun run g:build
 
 # Typecheck
 
-yarn g:typecheck
+bun run g:typecheck
 
 # Lint
 
-yarn g:lint
+bun run g:lint
 
 # Test
 
-yarn g:test
+bun run g:test
 
 # Run a specific package.json command for an individual SDK
 
-yarn sdk @uniswap/{sdk-name} {command}
+bun run sdk @uniswap/{sdk-name} {command}
 ```
 
 ## Making Changes & Publishing
@@ -85,7 +85,7 @@ Previously this required 4 sequential PRs with publish-wait-bump cycles. Now it'
 
 ```
 1. Edit sdk-core (add chain) + universal-router-sdk (use chain)
-2. Run `yarn changeset` and select both packages
+2. Run `bun run changeset` and select both packages
 3. Open PR, merge
 4. Merge the auto-generated "Version Packages" PR
 5. All affected packages publish to npm

--- a/README.md
+++ b/README.md
@@ -6,18 +6,31 @@ A repository for many Uniswap SDK's. All SDK's can be found in `sdk/` and have m
 
 ```markdown
 # Clone
+
 git clone --recurse-submodules https://github.com/Uniswap/sdks.git
+
 # Install
+
 yarn
+
 # Build
+
 yarn g:build
+
 # Typecheck
+
 yarn g:typecheck
+
 # Lint
+
 yarn g:lint
+
 # Test
+
 yarn g:test
+
 # Run a specific package.json command for an individual SDK
+
 yarn sdk @uniswap/{sdk-name} {command}
 ```
 
@@ -34,10 +47,11 @@ Internal dependencies (e.g., `v4-sdk` depending on `sdk-core`) use the `workspac
 After making your changes, run:
 
 ```
-yarn changeset
+bun run changeset
 ```
 
 This interactive CLI will ask you:
+
 - **Which packages should be bumped?** Select the packages you directly changed (e.g., `@uniswap/sdk-core`).
 - **What type of bump?** `patch`, `minor`, or `major`.
 - **Summary** A short description of the change (this becomes the changelog entry).
@@ -79,8 +93,8 @@ Previously this required 4 sequential PRs with publish-wait-bump cycles. Now it'
 
 ### Quick reference
 
-| Command | What it does |
-|---|---|
-| `yarn changeset` | Create a changeset file (run before opening your PR) |
-| `yarn version-packages` | Apply pending changesets to bump versions (CI does this) |
-| `yarn g:release` | Publish all bumped packages to npm (CI does this) |
+| Command                    | What it does                                             |
+| -------------------------- | -------------------------------------------------------- |
+| `bun run changeset`        | Create a changeset file (run before opening your PR)     |
+| `bun run version-packages` | Apply pending changesets to bump versions (CI does this) |
+| `bun run g:release`        | Publish all bumped packages to npm (CI does this)        |

--- a/sdks/sdk-core/src/addresses.test.ts
+++ b/sdks/sdk-core/src/addresses.test.ts
@@ -57,5 +57,10 @@ describe('addresses', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.TEMPO)
       expect(address).toEqual('0x7e9d53081e961201837336bcd81f52ae92691a8f')
     })
+
+    it('should return the correct address for megaeth', () => {
+      const address = SWAP_ROUTER_02_ADDRESSES(ChainId.MEGAETH)
+      expect(address).toEqual('0x48020de9208bafc183f5cad5118ffbe8f0f913f5')
+    })
   })
 })

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -65,6 +65,7 @@ export const V2_FACTORY_ADDRESSES: AddressMap = {
   [ChainId.XLAYER]: '0xdf38f24fe153761634be942f9d859f3dba857e95',
   [ChainId.LINEA]: '0x114A43DF6C5f54EBB8A9d70Cd1951D3dD68004c7',
   [ChainId.TEMPO]: '0xf9ec577a4e45b5278bb7cf60fcbc20c3acaef68f',
+  [ChainId.MEGAETH]: '0xbf56488c857a881ae7e3bed27cf99c10a7ab7e50',
 }
 /**
  * @deprecated use V2_ROUTER_ADDRESSES instead
@@ -91,6 +92,7 @@ export const V2_ROUTER_ADDRESSES: AddressMap = {
   [ChainId.XLAYER]: '0x182a927119d56008d921126764bf884221b10f59',
   [ChainId.LINEA]: '0x8702463e73f74d0b6765abceb314ef07acb92650',
   [ChainId.TEMPO]: '0x0fbac3c46f6f83b44c7fb4ea986d7309c701d73e',
+  [ChainId.MEGAETH]: '0xb73055db2b3a3eae87a331dd88e4a80b43602690',
 }
 
 // Networks that share most of the same addresses i.e. Mainnet, Goerli, Optimism, Arbitrum, Polygon
@@ -493,6 +495,22 @@ const TEMPO_ADDRESSES: ChainAddresses = {
   v4QuoterAddress: '0x20e6487c371a2086f841ef453f85378223df4f4e',
 }
 
+const MEGAETH_ADDRESSES: ChainAddresses = {
+  v3CoreFactoryAddress: '0x3a5f0cd7d62452b7f899b2a5758bfa57be0de478',
+  multicallAddress: '0x61f3272a3619d9f20788c6822fed2e5471bfc477',
+  quoterAddress: '0x5affda77bc34d945f9632bd080ebfcf24133b90e',
+  v3MigratorAddress: '0xed30f6c25fe915dc710f168fa3ab66199ee84454',
+  nonfungiblePositionManagerAddress: '0xcdc86e98184e96436f733a8bf31bd4f0214e6d7d',
+  tickLensAddress: '0xe7a2d824722addcb21e7a203ae7b372bf3a29ec5',
+  swapRouter02Address: '0x48020de9208bafc183f5cad5118ffbe8f0f913f5',
+  mixedRouteQuoterV2Address: '0x1768d0b0f8ee6638986aab8f775ceb87c45f8730',
+
+  v4PoolManagerAddress: '0xacb7e78fa05d562e0a5d3089ec896d57d057d38e',
+  v4PositionManagerAddress: '0x9ae0921e981aaa7308f176f8d4f9129b9247c89d',
+  v4StateView: '0x726f84e1dfb8d375a365e0808282f40d52d3e4e8',
+  v4QuoterAddress: '0x94bdc671f0c35f44a1daa53143fd1f868d1623b9',
+}
+
 export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses> = {
   [ChainId.MAINNET]: MAINNET_ADDRESSES,
   [ChainId.OPTIMISM]: OPTIMISM_ADDRESSES,
@@ -526,6 +544,7 @@ export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses>
   [ChainId.XLAYER]: XLAYER_ADDRESSES,
   [ChainId.LINEA]: LINEA_ADDRESSES,
   [ChainId.TEMPO]: TEMPO_ADDRESSES,
+  [ChainId.MEGAETH]: MEGAETH_ADDRESSES,
 }
 
 /* V3 Contract Addresses */

--- a/sdks/sdk-core/src/chains.test.ts
+++ b/sdks/sdk-core/src/chains.test.ts
@@ -5,6 +5,7 @@ describe('getAverageBlockTimeSecs', () => {
     expect(getAverageBlockTimeSecs(ChainId.MAINNET)).toEqual(12)
     expect(getAverageBlockTimeSecs(ChainId.ARBITRUM_ONE)).toEqual(0.25)
     expect(getAverageBlockTimeSecs(ChainId.ROBINHOOD)).toEqual(0.1)
+    expect(getAverageBlockTimeSecs(ChainId.MEGAETH)).toEqual(1)
   })
 
   it('throws on unregistered chainId', () => {
@@ -17,6 +18,7 @@ describe('secondsToBlocks', () => {
     expect(secondsToBlocks(8, ChainId.MAINNET)).toEqual(1) // ceil(8/12)
     expect(secondsToBlocks(8, ChainId.ARBITRUM_ONE)).toEqual(32) // ceil(8/0.25)
     expect(secondsToBlocks(8, ChainId.TEMPO)).toEqual(16) // ceil(8/0.5)
+    expect(secondsToBlocks(8, ChainId.MEGAETH)).toEqual(8) // ceil(8/1)
     expect(secondsToBlocks(1, ChainId.MAINNET)).toEqual(1) // ceil(1/12) — rounds up to a full block
   })
 

--- a/sdks/sdk-core/src/chains.ts
+++ b/sdks/sdk-core/src/chains.ts
@@ -34,6 +34,7 @@ export enum ChainId {
   XLAYER = 196,
   LINEA = 59144,
   TEMPO = 4217,
+  MEGAETH = 4326,
   ROBINHOOD = 46630,
 }
 
@@ -62,6 +63,7 @@ export const AVERAGE_BLOCK_TIMES_SECONDS: { [chainId: number]: number } = {
   [ChainId.MONAD]: 0.4,
   [ChainId.XLAYER]: 1,
   [ChainId.TEMPO]: 0.5,
+  [ChainId.MEGAETH]: 1,
   [ChainId.ROBINHOOD]: 0.1,
 }
 
@@ -121,6 +123,7 @@ export const SUPPORTED_CHAINS = [
   ChainId.XLAYER,
   ChainId.LINEA,
   ChainId.TEMPO,
+  ChainId.MEGAETH,
 ] as const
 export type SupportedChainsType = (typeof SUPPORTED_CHAINS)[number]
 

--- a/sdks/sdk-core/src/entities/weth9.ts
+++ b/sdks/sdk-core/src/entities/weth9.ts
@@ -35,4 +35,5 @@ export const WETH9: { [chainId: number]: Token } = {
   1868: new Token(1868, '0x4200000000000000000000000000000000000006', 18, 'WETH', 'Wrapped Ether'),
   143: new Token(143, '0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A', 18, 'WMON', 'Wrapped Monad'),
   59144: new Token(59144, '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f', 18, 'WETH', 'Wrapped Ether'),
+  4326: new Token(4326, '0x4200000000000000000000000000000000000006', 18, 'WETH', 'Wrapped Ether'),
 }

--- a/sdks/universal-router-sdk/src/utils/constants.ts
+++ b/sdks/universal-router-sdk/src/utils/constants.ts
@@ -498,6 +498,21 @@ export const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     },
     swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,
   },
+  // megaeth
+  [4326]: {
+    weth: '0x4200000000000000000000000000000000000006',
+    routerConfigs: {
+      [UniversalRouterVersion.V2_0]: {
+        address: '0x48fd03529d2a91be835f07f6b72f53b4aad6093d',
+        creationBlock: 7009661,
+      },
+      [UniversalRouterVersion.V2_1_1]: {
+        address: '0x47837eb80db5908eabba9105626d9b348bea7b02',
+        creationBlock: 7009661,
+      },
+    },
+    swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,
+  },
   // xlayer
   [196]: {
     weth: '0xe538905cf8410324e03A5A23C1c177a474D59b2b',

--- a/sdks/universal-router-sdk/test/utils/constants.test.ts
+++ b/sdks/universal-router-sdk/test/utils/constants.test.ts
@@ -35,6 +35,11 @@ describe('Universal Router Constants', () => {
       expect(() => UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, 59144)).to.throw(
         'Universal Router version 1.2 not deployed on chain 59144'
       )
+
+      // MegaETH (4326) has no V1_2
+      expect(() => UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, 4326)).to.throw(
+        'Universal Router version 1.2 not deployed on chain 4326'
+      )
     })
   })
 
@@ -61,6 +66,11 @@ describe('Universal Router Constants', () => {
       // Linea (59144) has no V1_2
       expect(() => UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V1_2, 59144)).to.throw(
         'Universal Router version 1.2 not deployed on chain 59144'
+      )
+
+      // MegaETH (4326) has no V1_2
+      expect(() => UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V1_2, 4326)).to.throw(
+        'Universal Router version 1.2 not deployed on chain 4326'
       )
     })
   })


### PR DESCRIPTION
## Description

Adds MegaETH (`chainId` `4326`) support across the SDK constants needed for routing and Universal Router usage.

## Changes

### sdk-core

- Added `ChainId.MEGAETH = 4326` and included it in `SUPPORTED_CHAINS`.
- Registered MegaETH's `1` second average block time for block-window helpers.
- Added MegaETH WETH (`0x4200000000000000000000000000000000000006`).
- Added MegaETH V2, V3, and V4 deployment addresses, including the SDK multicall address, Swap Router 02, mixed-route quoter, and V4 manager/view/quoter contracts.

### universal-router-sdk

- Added MegaETH `CHAIN_CONFIGS[4326]` with WETH, `V2_0`, and `V2_1_1` Universal Router deployments.
- Configured MegaETH to use `SWAP_PROXY_DEPLOY_ADDRESS`.
- Intentionally omitted `UniversalRouterVersion.V1_2` because it is not deployed on MegaETH.

## How Has This Been Tested?

- `bun run --filter @uniswap/sdk-core test` passed: `370 pass`.
- `git diff --check` passed.
- `bun run test:hardhat test/utils/constants.test.ts` in `sdks/universal-router-sdk` executed the constants assertions successfully: `154 passing`, including MegaETH `V2_0`, `V2_1_1`, and unsupported `V1_2` coverage. Hardhat then exited with `[Error: relative URL without a base]` after the tests completed.

Known existing validation blockers outside this PR's changed constants:

- `bun run --filter @uniswap/universal-router-sdk test` fails during Hardhat startup because `@uniswap/v4-sdk` does not export `URVersion` for existing imports in `src/entities/actions/uniswap.ts` / `src/utils/encodeV4Action.ts`.
- `bun run --filter @uniswap/universal-router-sdk build` fails on the same existing `URVersion` / V4 SDK API mismatch.
- `bun run --filter @uniswap/universal-router-sdk test:forge` compiles successfully, then fails setup because `FORK_URL` is not set.

## Are there any breaking changes?

No. This only adds MegaETH constants and tests; existing chain behavior is unchanged.

## (Optional) Feedback Focus

Please double-check the supplied MegaETH deployment addresses and the mapping of the Universal Router v2.1 deployment to `UniversalRouterVersion.V2_1_1`.

## (Optional) Follow Ups

None for this PR. UniswapX and smart wallet support are intentionally out of scope.
