### PR TITLE
feat(ur-sdk): add UniversalRouterVersion V2_2_0 with Sepolia perm-pool addresses

### DIFF
--- a/sdks/router-sdk/CHANGELOG.md
+++ b/sdks/router-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @uniswap/router-sdk
 
+## 2.10.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.0
+  - @uniswap/v4-sdk@2.2.0
+  - @uniswap/v2-sdk@4.20.2
+  - @uniswap/v3-sdk@3.30.2
+
 ## 2.10.1
 
 ### Patch Changes

--- a/sdks/router-sdk/package.json
+++ b/sdks/router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/router-sdk",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/sdk-core/CHANGELOG.md
+++ b/sdks/sdk-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uniswap/sdk-core
 
+## 7.16.0
+
+### Minor Changes
+
+- Add UniversalRouterVersion V2_2_0 (Sepolia) with permissioned-pool support
+
 ## 7.15.0
 
 ### Minor Changes

--- a/sdks/sdk-core/package.json
+++ b/sdks/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/sdk-core",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -18,6 +18,7 @@ type ChainAddresses = {
   v4PositionManagerAddress?: string
   v4StateView?: string
   v4QuoterAddress?: string
+  permissionedV4PositionManagerAddress?: string
 }
 
 const DEFAULT_NETWORKS = [ChainId.MAINNET, ChainId.GOERLI, ChainId.SEPOLIA]
@@ -241,6 +242,7 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   v4PositionManagerAddress: '0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4',
   v4StateView: '0xe1dd9c3fa50edb962e442f60dfbc432e24537e4c',
   v4QuoterAddress: '0x61b3f2011a92d183c7dbadbda940a7555ccf9227',
+  permissionedV4PositionManagerAddress: '0x96a866F17eC1e53f184C3F997D0dc026035aFe16',
 }
 
 // Avalanche v3 addresses

--- a/sdks/smart-wallet-sdk/CHANGELOG.md
+++ b/sdks/smart-wallet-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @uniswap/smart-wallet-sdk
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.0
+
 ## 2.6.1
 
 ### Patch Changes

--- a/sdks/smart-wallet-sdk/package.json
+++ b/sdks/smart-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-wallet-sdk",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "⚒️ An SDK for building applications with smart wallets on Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/uniswapx-sdk/CHANGELOG.md
+++ b/sdks/uniswapx-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @uniswap/uniswapx-sdk
 
+## 3.0.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.0
+
 ## 3.0.4
 
 ### Patch Changes

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswapx-sdk",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "author": "Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/universal-router-sdk/CHANGELOG.md
+++ b/sdks/universal-router-sdk/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @uniswap/universal-router-sdk
 
+## 5.5.0
+
+### Minor Changes
+
+- Add UniversalRouterVersion V2_2_0 (Sepolia) with permissioned-pool support
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.0
+  - @uniswap/v4-sdk@2.2.0
+  - @uniswap/router-sdk@2.10.2
+  - @uniswap/v2-sdk@4.20.2
+  - @uniswap/v3-sdk@3.30.2
+
 ## 5.4.0
 
 ### Minor Changes

--- a/sdks/universal-router-sdk/package.json
+++ b/sdks/universal-router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/universal-router-sdk",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "sdk for integrating with the Universal Router contracts",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/universal-router-sdk/src/entities/actions/uniswap.ts
+++ b/sdks/universal-router-sdk/src/entities/actions/uniswap.ts
@@ -69,6 +69,7 @@ export type SwapOptions = Omit<RouterSwapOptions, 'inputTokenPermit'> & {
 const UR_VERSION_MAP: Record<string, URVersion> = {
   [UniversalRouterVersion.V2_0]: URVersion.V2_0,
   [UniversalRouterVersion.V2_1_1]: URVersion.V2_1_1,
+  [UniversalRouterVersion.V2_2_0]: URVersion.V2_2_0,
 }
 
 function toURVersion(version?: UniversalRouterVersion): URVersion {

--- a/sdks/universal-router-sdk/src/utils/constants.ts
+++ b/sdks/universal-router-sdk/src/utils/constants.ts
@@ -4,6 +4,7 @@ export enum UniversalRouterVersion {
   V1_2 = '1.2',
   V2_0 = '2.0',
   V2_1_1 = '2.1.1',
+  V2_2_0 = '2.2.0',
 }
 
 /**
@@ -79,6 +80,10 @@ export const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
       [UniversalRouterVersion.V2_1_1]: {
         address: '0x8B844f885672f333Bc0042cB669255f93a4C1E6b',
         creationBlock: 10470160,
+      },
+      [UniversalRouterVersion.V2_2_0]: {
+        address: '0x36aDBb78ebA5C9e04A8Dd700464329D442464553',
+        creationBlock: 10927672,
       },
     },
     swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,

--- a/sdks/v2-sdk/CHANGELOG.md
+++ b/sdks/v2-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @uniswap/v2-sdk
 
+## 4.20.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.0
+
 ## 4.20.1
 
 ### Patch Changes

--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v2-sdk",
-  "version": "4.20.1",
+  "version": "4.20.2",
   "description": "🛠 An SDK for building applications on top of Uniswap V2",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/v3-sdk/CHANGELOG.md
+++ b/sdks/v3-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @uniswap/v3-sdk
 
+## 3.30.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.0
+
 ## 3.30.1
 
 ### Patch Changes

--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v3-sdk",
-  "version": "3.30.1",
+  "version": "3.30.2",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/v4-sdk/CHANGELOG.md
+++ b/sdks/v4-sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @uniswap/v4-sdk
 
+## 2.2.0
+
+### Minor Changes
+
+- Add UniversalRouterVersion V2_2_0 (Sepolia) with permissioned-pool support
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.0
+  - @uniswap/v3-sdk@3.30.2
+
 ## 2.1.1
 
 ### Patch Changes

--- a/sdks/v4-sdk/package.json
+++ b/sdks/v4-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v4-sdk",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "⚒️ An SDK for building applications on top of Uniswap V4",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/v4-sdk/src/utils/v4Planner.ts
+++ b/sdks/v4-sdk/src/utils/v4Planner.ts
@@ -19,6 +19,7 @@ import { encodeRouteToPath } from './encodeRouteToPath'
 export enum URVersion {
   V2_0 = '2.0',
   V2_1_1 = '2.1.1',
+  V2_2_0 = '2.2.0',
 }
 
 export function isAtLeastV2_1_1(version?: string): boolean {


### PR DESCRIPTION
## Summary

Adds `UniversalRouterVersion.V2_2_0` and the corresponding Sepolia address mapping for the freshly redeployed Universal Router that
supports permissioned pools. Also adds `permissionedV4PositionManagerAddress` to `ChainAddresses` and a Sepolia entry for it.
  
Adds the sepolia addresses:
- UR V2.2.0 Sepolia: `0x36aDBb78ebA5C9e04A8Dd700464329D442464553` (creationBlock 10927672)
- PermissionedPositionManager Sepolia: `0x96a866F17eC1e53f184C3F997D0dc026035aFe16`
  
## How Has This Been Tested?

Type-check pending via CI.

## Are there any breaking changes?

No. All additions are new enum values / new optional address fields.