### PR TITLE
feat(sdks): add mainnet perm-pool addresses, update sepolia perm-pool redeploy (UR V2_2_0 + position
  manager)

### DIFF
--- a/sdks/router-sdk/CHANGELOG.md
+++ b/sdks/router-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @uniswap/router-sdk
 
+## 2.10.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.1
+  - @uniswap/v4-sdk@2.2.1
+  - @uniswap/v2-sdk@4.20.3
+  - @uniswap/v3-sdk@3.30.3
+
 ## 2.10.2
 
 ### Patch Changes

--- a/sdks/router-sdk/package.json
+++ b/sdks/router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/router-sdk",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/sdk-core/CHANGELOG.md
+++ b/sdks/sdk-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uniswap/sdk-core
 
+## 7.16.1
+
+### Patch Changes
+
+- Add mainnet permissioned V4 position manager address and update sepolia permissioned V4 position manager address (perm-pool redeploy)
+
 ## 7.16.0
 
 ### Minor Changes

--- a/sdks/sdk-core/package.json
+++ b/sdks/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/sdk-core",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -112,6 +112,7 @@ const MAINNET_ADDRESSES: ChainAddresses = {
   v4PositionManagerAddress: '0xbd216513d74c8cf14cf4747e6aaa6420ff64ee9e',
   v4StateView: '0x7ffe42c4a5deea5b0fec41c94c136cf115597227',
   v4QuoterAddress: '0x52f0e24d1c21c8a0cb1e5a5dd6198556bd9e1203',
+  permissionedV4PositionManagerAddress: '0x89628C9B4CE81951a9BC1F36F0688Fad6A6ee248',
 }
 const GOERLI_ADDRESSES: ChainAddresses = {
   ...DEFAULT_ADDRESSES,
@@ -242,7 +243,7 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   v4PositionManagerAddress: '0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4',
   v4StateView: '0xe1dd9c3fa50edb962e442f60dfbc432e24537e4c',
   v4QuoterAddress: '0x61b3f2011a92d183c7dbadbda940a7555ccf9227',
-  permissionedV4PositionManagerAddress: '0x96a866F17eC1e53f184C3F997D0dc026035aFe16',
+  permissionedV4PositionManagerAddress: '0x68fC145BB20b388965bED184Df5ef912215bb3C7',
 }
 
 // Avalanche v3 addresses

--- a/sdks/smart-wallet-sdk/CHANGELOG.md
+++ b/sdks/smart-wallet-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @uniswap/smart-wallet-sdk
 
+## 2.6.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.1
+
 ## 2.6.2
 
 ### Patch Changes

--- a/sdks/smart-wallet-sdk/package.json
+++ b/sdks/smart-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-wallet-sdk",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "⚒️ An SDK for building applications with smart wallets on Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/uniswapx-sdk/CHANGELOG.md
+++ b/sdks/uniswapx-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @uniswap/uniswapx-sdk
 
+## 3.0.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.1
+
 ## 3.0.5
 
 ### Patch Changes

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswapx-sdk",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "author": "Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/universal-router-sdk/CHANGELOG.md
+++ b/sdks/universal-router-sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @uniswap/universal-router-sdk
 
+## 5.5.1
+
+### Patch Changes
+
+- Add mainnet UniversalRouterVersion V2_2_0 router config and update sepolia V2_2_0 address (perm-pool redeploy)
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.1
+  - @uniswap/v4-sdk@2.2.1
+  - @uniswap/router-sdk@2.10.3
+  - @uniswap/v2-sdk@4.20.3
+  - @uniswap/v3-sdk@3.30.3
+
 ## 5.5.0
 
 ### Minor Changes

--- a/sdks/universal-router-sdk/package.json
+++ b/sdks/universal-router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/universal-router-sdk",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "sdk for integrating with the Universal Router contracts",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/universal-router-sdk/src/utils/constants.ts
+++ b/sdks/universal-router-sdk/src/utils/constants.ts
@@ -48,6 +48,10 @@ export const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
         address: '0x4C82D1fBFe28C977cBB58D8C7FF8FCF9F70a2cCA',
         creationBlock: 24680568,
       },
+      [UniversalRouterVersion.V2_2_0]: {
+        address: '0xCb640A86855f1A828c27241bA364348de28abe66',
+        creationBlock: 25195294,
+      },
     },
     swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,
   },
@@ -82,8 +86,8 @@ export const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
         creationBlock: 10470160,
       },
       [UniversalRouterVersion.V2_2_0]: {
-        address: '0x36aDBb78ebA5C9e04A8Dd700464329D442464553',
-        creationBlock: 10927672,
+        address: '0xB0C89059d7190EDb17eFF19829cc009cEe923916',
+        creationBlock: 10941522,
       },
     },
     swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,

--- a/sdks/v2-sdk/CHANGELOG.md
+++ b/sdks/v2-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @uniswap/v2-sdk
 
+## 4.20.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.1
+
 ## 4.20.2
 
 ### Patch Changes

--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v2-sdk",
-  "version": "4.20.2",
+  "version": "4.20.3",
   "description": "🛠 An SDK for building applications on top of Uniswap V2",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/v3-sdk/CHANGELOG.md
+++ b/sdks/v3-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @uniswap/v3-sdk
 
+## 3.30.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.1
+
 ## 3.30.2
 
 ### Patch Changes

--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v3-sdk",
-  "version": "3.30.2",
+  "version": "3.30.3",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/v4-sdk/CHANGELOG.md
+++ b/sdks/v4-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @uniswap/v4-sdk
 
+## 2.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @uniswap/sdk-core@7.16.1
+  - @uniswap/v3-sdk@3.30.3
+
 ## 2.2.0
 
 ### Minor Changes

--- a/sdks/v4-sdk/package.json
+++ b/sdks/v4-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v4-sdk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "⚒️ An SDK for building applications on top of Uniswap V4",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [


### PR DESCRIPTION
## Summary

Records the freshly redeployed permissioned-pool addresses on **mainnet** and updates **sepolia** after the redeploy. Sibling to #590 (which introduced `UniversalRouterVersion.V2_2_0` and the `permissionedV4PositionManagerAddress` field). Data-only — reuses the existing `V2_2_0` enum (same perm-pool Universal Router, redeployed).

### Mainnet (added)
- PermissionedPositionManager: `0x89628C9B4CE81951a9BC1F36F0688Fad6A6ee248`
- Universal Router `V2_2_0`: `0xCb640A86855f1A828c27241bA364348de28abe66` (creationBlock `25195294`)

### Sepolia (updated for redeploy)
- PermissionedPositionManager: `0x96a866…aFe16` → `0x68fC145BB20b388965bED184Df5ef912215bb3C7`
- Universal Router `V2_2_0`: `0x36aDBb78…64553` → `0xB0C89059d7190EDb17eFF19829cc009cEe923916` (creationBlock `10927672` → `10941522`)

## How Has This Been Tested?

- `turbo run build` (tsc typecheck) passes across `sdk-core`, `universal-router-sdk`, and all dependents.
- `universal-router-sdk` constants tests pass — `V2_2_0` now validated on chain `1` and `11155111`.
- `sdk-core` ESLint clean.

## Are there any breaking changes?

No. Additive address data + patch version bumps only.
