### PR TITLE
fix(ur-sdk): Fix and improve v4 ur mapping

### DIFF
--- a/.changeset/bright-crews-know.md
+++ b/.changeset/bright-crews-know.md
@@ -1,5 +1,0 @@
----
-"@uniswap/universal-router-sdk": patch
----
-
-Fix UR version mapping with v4-sdk

--- a/.changeset/bright-crews-know.md
+++ b/.changeset/bright-crews-know.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/universal-router-sdk": patch
+---
+
+Fix UR version mapping with v4-sdk

--- a/sdks/universal-router-sdk/CHANGELOG.md
+++ b/sdks/universal-router-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uniswap/universal-router-sdk
 
+## 5.5.2
+
+### Patch Changes
+
+- 5d35ab3: Fix UR version mapping with v4-sdk
+
 ## 5.5.1
 
 ### Patch Changes

--- a/sdks/universal-router-sdk/CHANGELOG.md
+++ b/sdks/universal-router-sdk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- 5d35ab3: Fix UR version mapping with v4-sdk
+- Fix UR version mapping with v4-sdk
 
 ## 5.5.1
 

--- a/sdks/universal-router-sdk/package.json
+++ b/sdks/universal-router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/universal-router-sdk",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "sdk for integrating with the Universal Router contracts",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/universal-router-sdk/src/entities/actions/uniswap.ts
+++ b/sdks/universal-router-sdk/src/entities/actions/uniswap.ts
@@ -8,7 +8,6 @@ import {
   V4Planner,
   encodeRouteToPath as encodeV4RouteToPath,
   Actions,
-  URVersion,
 } from '@uniswap/v4-sdk'
 import {
   Trade as RouterTrade,
@@ -26,6 +25,7 @@ import {
 } from '@uniswap/router-sdk'
 import { Permit2Permit } from '../../utils/inputTokens'
 import { getPathCurrency } from '../../utils/pathCurrency'
+import { toV4URVersion } from '../../utils/toV4URVersion'
 import { Currency, TradeType, Token, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { Command, RouterActionType, TradeConfig } from '../Command'
 import {
@@ -63,20 +63,6 @@ export type SwapOptions = Omit<RouterSwapOptions, 'inputTokenPermit'> & {
   urVersion?: UniversalRouterVersion // Universal Router version for encoding (defaults to V2_0 for backward compatibility)
   tokenTransferMode?: TokenTransferMode // How input tokens are transferred to the UR (defaults to Permit2). ApproveProxy uses the SwapProxy contract.
   chainId?: number // Required when tokenTransferMode is ApproveProxy, used to resolve UR address for the proxy
-}
-
-/** Map from UniversalRouterVersion to v4-sdk's URVersion for v4 planner calls */
-const UR_VERSION_MAP: Record<string, URVersion> = {
-  [UniversalRouterVersion.V2_0]: URVersion.V2_0,
-  [UniversalRouterVersion.V2_1_1]: URVersion.V2_1_1,
-  [UniversalRouterVersion.V2_2_0]: URVersion.V2_2_0,
-}
-
-function toURVersion(version?: UniversalRouterVersion): URVersion {
-  if (version === undefined) return URVersion.V2_0
-  const mapped = UR_VERSION_MAP[version]
-  if (!mapped) throw new Error(`No v4-sdk URVersion mapping for UniversalRouterVersion: ${version}`)
-  return mapped
 }
 
 const REFUND_ETH_PRICE_IMPACT_THRESHOLD = new Percent(50, 100)
@@ -495,7 +481,7 @@ function addV4Swap<TInput extends Currency, TOutput extends Currency>(
   const perHopSlippage = minHopPriceX36?.map((s) => BigNumber.from(s)) ?? []
 
   const v4Planner = new V4Planner()
-  v4Planner.addTrade(trade, slippageToleranceOnSwap, perHopSlippage, toURVersion(options.urVersion))
+  v4Planner.addTrade(trade, slippageToleranceOnSwap, perHopSlippage, toV4URVersion(options.urVersion))
   v4Planner.addSettle(trade.route.pathInput, payerIsUser)
 
   // Handle split route output consistency:
@@ -620,7 +606,7 @@ function addMixedSwap<TInput extends Currency, TOutput extends Currency>(
             amountOutMinimum: !isLastSectionInRoute(i) ? 0 : amountOut,
           },
         ],
-        toURVersion(options.urVersion)
+        toV4URVersion(options.urVersion)
       )
 
       // Handle split route output consistency for V4 sections in mixed routes

--- a/sdks/universal-router-sdk/src/utils/encodeSwapStep.ts
+++ b/sdks/universal-router-sdk/src/utils/encodeSwapStep.ts
@@ -2,7 +2,8 @@ import { V4Planner } from '@uniswap/v4-sdk'
 import { UniversalRouterVersion, isAtLeastV2_1_1 } from './constants'
 import { CommandType, RoutePlanner } from './routerCommands'
 import { SwapStep } from '../types/encodeSwaps'
-import { encodeV4Action, toV4URVersion } from './encodeV4Action'
+import { encodeV4Action } from './encodeV4Action'
+import { toV4URVersion } from './toV4URVersion'
 
 // V2/V3 swap params hardcode payerIsUser=false; encodeSwaps pulls funds into the router first via PERMIT2_TRANSFER_FROM
 export function encodeSwapStep(planner: RoutePlanner, step: SwapStep, urVersion?: UniversalRouterVersion): void {

--- a/sdks/universal-router-sdk/src/utils/encodeV4Action.ts
+++ b/sdks/universal-router-sdk/src/utils/encodeV4Action.ts
@@ -1,22 +1,10 @@
-import { Actions, URVersion } from '@uniswap/v4-sdk'
+import { Actions } from '@uniswap/v4-sdk'
 import { UniversalRouterVersion, isAtLeastV2_1_1 } from './constants'
 import { V4Action } from '../types/encodeSwaps'
 
 const ACTION_NAME_TO_ENUM: { [key: string]: Actions } = Object.fromEntries(
   Object.entries(Actions).filter(([key]) => isNaN(Number(key)))
 ) as { [key: string]: Actions }
-
-const V4_UR_VERSION_MAP: Record<string, URVersion> = {
-  [UniversalRouterVersion.V2_0]: URVersion.V2_0,
-  [UniversalRouterVersion.V2_1_1]: URVersion.V2_1_1,
-}
-
-export function toV4URVersion(version?: UniversalRouterVersion): URVersion {
-  if (version === undefined) return URVersion.V2_0
-  const mapped = V4_UR_VERSION_MAP[version]
-  if (!mapped) throw new Error(`No v4-sdk URVersion mapping for UniversalRouterVersion: ${version}`)
-  return mapped
-}
 
 export function encodeV4Action(
   v4Action: V4Action,

--- a/sdks/universal-router-sdk/src/utils/toV4URVersion.ts
+++ b/sdks/universal-router-sdk/src/utils/toV4URVersion.ts
@@ -1,0 +1,15 @@
+import { URVersion } from '@uniswap/v4-sdk'
+import { UniversalRouterVersion } from './constants'
+
+// the one sanctioned bridge to v4-sdk's URVersion — kept out of constants.ts on purpose (see isAtLeastV2_1_1 note there)
+// so the widely-imported constants leaf stays free of v4-sdk. UniversalRouterVersion and URVersion share string values,
+// so resolve by value: new versions map without code changes, as long as both enums stay in sync.
+const URVERSION_VALUES = new Set<string>(Object.values(URVersion))
+
+export function toV4URVersion(version?: UniversalRouterVersion): URVersion {
+  if (version === undefined) return URVersion.V2_0
+  if (!URVERSION_VALUES.has(version)) {
+    throw new Error(`No v4-sdk URVersion mapping for UniversalRouterVersion: ${version}`)
+  }
+  return version as unknown as URVersion
+}

--- a/sdks/universal-router-sdk/src/utils/toV4URVersion.ts
+++ b/sdks/universal-router-sdk/src/utils/toV4URVersion.ts
@@ -1,8 +1,7 @@
 import { URVersion } from '@uniswap/v4-sdk'
 import { UniversalRouterVersion } from './constants'
 
-// the one sanctioned bridge to v4-sdk's URVersion — kept out of constants.ts on purpose (see isAtLeastV2_1_1 note there)
-// so the widely-imported constants leaf stays free of v4-sdk. UniversalRouterVersion and URVersion share string values,
+// the one sanctioned bridge to v4-sdk's URVersion — UniversalRouterVersion and URVersion share string values,
 // so resolve by value: new versions map without code changes, as long as both enums stay in sync.
 const URVERSION_VALUES = new Set<string>(Object.values(URVersion))
 

--- a/sdks/universal-router-sdk/test/unit/toV4URVersion.test.ts
+++ b/sdks/universal-router-sdk/test/unit/toV4URVersion.test.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai'
+import { URVersion } from '@uniswap/v4-sdk'
+import { toV4URVersion } from '../../src/utils/toV4URVersion'
+import { UniversalRouterVersion } from '../../src/utils/constants'
+
+describe('toV4URVersion', () => {
+  it('maps each UR version to the matching v4-sdk URVersion', () => {
+    expect(toV4URVersion(UniversalRouterVersion.V2_0)).to.equal(URVersion.V2_0)
+    expect(toV4URVersion(UniversalRouterVersion.V2_1_1)).to.equal(URVersion.V2_1_1)
+    // regression: a newly-added UR version must resolve without touching this map
+    expect(toV4URVersion(UniversalRouterVersion.V2_2_0)).to.equal(URVersion.V2_2_0)
+  })
+
+  it('defaults to V2_0 when version is undefined', () => {
+    expect(toV4URVersion(undefined)).to.equal(URVersion.V2_0)
+  })
+
+  it('throws for UR versions with no v4-sdk equivalent', () => {
+    // v4 actions do not exist pre-V2, so V1_2 has no URVersion
+    expect(() => toV4URVersion(UniversalRouterVersion.V1_2)).to.throw(/No v4-sdk URVersion mapping/)
+  })
+
+  it('throws for an unknown version value', () => {
+    expect(() => toV4URVersion('9.9.9' as UniversalRouterVersion)).to.throw(/No v4-sdk URVersion mapping/)
+  })
+
+  // contract: every UR version whose string also exists in URVersion must resolve to it.
+  // guards both enums staying in sync as new contract versions land.
+  it('resolves every UR version that shares a string with URVersion', () => {
+    const urVersionValues = new Set<string>(Object.values(URVersion))
+    for (const version of Object.values(UniversalRouterVersion)) {
+      if (urVersionValues.has(version)) {
+        expect(toV4URVersion(version)).to.equal(version)
+      } else {
+        expect(() => toV4URVersion(version)).to.throw(/No v4-sdk URVersion mapping/)
+      }
+    }
+  })
+})

--- a/sdks/universal-router-sdk/test/unit/toV4URVersion.test.ts
+++ b/sdks/universal-router-sdk/test/unit/toV4URVersion.test.ts
@@ -7,7 +7,6 @@ describe('toV4URVersion', () => {
   it('maps each UR version to the matching v4-sdk URVersion', () => {
     expect(toV4URVersion(UniversalRouterVersion.V2_0)).to.equal(URVersion.V2_0)
     expect(toV4URVersion(UniversalRouterVersion.V2_1_1)).to.equal(URVersion.V2_1_1)
-    // regression: a newly-added UR version must resolve without touching this map
     expect(toV4URVersion(UniversalRouterVersion.V2_2_0)).to.equal(URVersion.V2_2_0)
   })
 
@@ -17,11 +16,11 @@ describe('toV4URVersion', () => {
 
   it('throws for UR versions with no v4-sdk equivalent', () => {
     // v4 actions do not exist pre-V2, so V1_2 has no URVersion
-    expect(() => toV4URVersion(UniversalRouterVersion.V1_2)).to.throw(/No v4-sdk URVersion mapping/)
+    expect(() => toV4URVersion(UniversalRouterVersion.V1_2)).to.throw('No v4-sdk URVersion mapping')
   })
 
   it('throws for an unknown version value', () => {
-    expect(() => toV4URVersion('9.9.9' as UniversalRouterVersion)).to.throw(/No v4-sdk URVersion mapping/)
+    expect(() => toV4URVersion('9.9.9' as UniversalRouterVersion)).to.throw('No v4-sdk URVersion mapping')
   })
 
   // contract: every UR version whose string also exists in URVersion must resolve to it.
@@ -32,7 +31,7 @@ describe('toV4URVersion', () => {
       if (urVersionValues.has(version)) {
         expect(toV4URVersion(version)).to.equal(version)
       } else {
-        expect(() => toV4URVersion(version)).to.throw(/No v4-sdk URVersion mapping/)
+        expect(() => toV4URVersion(version)).to.throw('No v4-sdk URVersion mapping')
       }
     }
   })


### PR DESCRIPTION
## PR Scope

Please title your PR according to the following types and scopes following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/):

- `fix(SDK name):` will trigger a patch version
- `chore(<type>):` will not trigger any release and should be used for internal repo changes
- `<type>(public):` will trigger a patch version for non-code changes (e.g. README changes)
- `feat(SDK name):` will trigger a minor version
- `feat(breaking):` will trigger a major version for a breaking change

## Description

`toV4URVersion` is an anti-corruption layer between the UR-SDK and v4-sdk version models. This is to make it so devs don't ned to update a mapping when new Universal Router versions are released, just the one enum in `constants.ts`.

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

_[e.g. Type definitions, API definitions]_

If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_
