### PR TITLE
feat(sdk-core): add Robinhood (4663) and Arc (5042) chain support

### DIFF
--- a/.changeset/robinhood-arc-chains.md
+++ b/.changeset/robinhood-arc-chains.md
@@ -1,0 +1,10 @@
+---
+"@uniswap/sdk-core": minor
+"@uniswap/universal-router-sdk": minor
+---
+
+Add Robinhood (4663) and Arc (5042) chain and Universal Router deployment config.
+
+Also corrects `ChainId.ROBINHOOD` from `46630` to `4663` to match the canonical Robinhood
+mainnet chain ID used across Uniswap's backend and the contracts deployments repo. Robinhood
+had no addresses wired up previously, so this is shipped as a minor bump.

--- a/sdks/sdk-core/src/addresses.test.ts
+++ b/sdks/sdk-core/src/addresses.test.ts
@@ -62,5 +62,15 @@ describe('addresses', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.MEGAETH)
       expect(address).toEqual('0x48020de9208bafc183f5cad5118ffbe8f0f913f5')
     })
+
+    it('should return the correct address for arc', () => {
+      const address = SWAP_ROUTER_02_ADDRESSES(ChainId.ARC)
+      expect(address).toEqual('0x53bf6b0684ec7ef91e1387da3d1a1769bc5a6f77')
+    })
+
+    it('should return the correct address for robinhood', () => {
+      const address = SWAP_ROUTER_02_ADDRESSES(ChainId.ROBINHOOD)
+      expect(address).toEqual('0xcaf681a66d020601342297493863e78c959e5cb2')
+    })
   })
 })

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -67,6 +67,8 @@ export const V2_FACTORY_ADDRESSES: AddressMap = {
   [ChainId.LINEA]: '0x114A43DF6C5f54EBB8A9d70Cd1951D3dD68004c7',
   [ChainId.TEMPO]: '0xf9ec577a4e45b5278bb7cf60fcbc20c3acaef68f',
   [ChainId.MEGAETH]: '0xbf56488c857a881ae7e3bed27cf99c10a7ab7e50',
+  [ChainId.ARC]: '0x89e5db8b5aa49aa85ac63f691524311aeb649eba',
+  [ChainId.ROBINHOOD]: '0x8bceaa40b9acdfaedf85adf4ff01f5ad6517937f',
 }
 /**
  * @deprecated use V2_ROUTER_ADDRESSES instead
@@ -94,6 +96,8 @@ export const V2_ROUTER_ADDRESSES: AddressMap = {
   [ChainId.LINEA]: '0x8702463e73f74d0b6765abceb314ef07acb92650',
   [ChainId.TEMPO]: '0x0fbac3c46f6f83b44c7fb4ea986d7309c701d73e',
   [ChainId.MEGAETH]: '0xb73055db2b3a3eae87a331dd88e4a80b43602690',
+  [ChainId.ARC]: '0x1f7d7550b1b028f7571e69a784071f0205fd2efa',
+  [ChainId.ROBINHOOD]: '0x89e5db8b5aa49aa85ac63f691524311aeb649eba',
 }
 
 // Networks that share most of the same addresses i.e. Mainnet, Goerli, Optimism, Arbitrum, Polygon
@@ -514,6 +518,34 @@ const MEGAETH_ADDRESSES: ChainAddresses = {
   v4QuoterAddress: '0x94bdc671f0c35f44a1daa53143fd1f868d1623b9',
 }
 
+const ARC_ADDRESSES: ChainAddresses = {
+  v3CoreFactoryAddress: '0xf0db7b58379503491d857db50ac9ece64c653918',
+  multicallAddress: '0x33e885ed0ec9bf04ecfb19341582aadcb4c8a9e7',
+  quoterAddress: '0x7dfd4f31be6814d2906bde155c3e1b146eac1468',
+  nonfungiblePositionManagerAddress: '0x39654a85a4c05127f5fd6ed22caec077a0fb1377',
+  tickLensAddress: '0x9eb8600665b55d10c1eb2316ca5127a9ca6e2e76',
+  swapRouter02Address: '0x53bf6b0684ec7ef91e1387da3d1a1769bc5a6f77',
+
+  v4PoolManagerAddress: '0x8366a39cc670b4001a1121b8f6a443a643e40951',
+  v4PositionManagerAddress: '0x6049c9a0e26405c0985f9e3685c87d0ae917f82b',
+  v4StateView: '0xf3334192d15450cdd385c8b70e03f9a6bd9e673b',
+  v4QuoterAddress: '0x8dc178efb8111bb0973dd9d722ebeff267c98f94',
+}
+
+const ROBINHOOD_ADDRESSES: ChainAddresses = {
+  v3CoreFactoryAddress: '0x1f7d7550b1b028f7571e69a784071f0205fd2efa',
+  multicallAddress: '0x282a3c4d320cc7f0d5eaf56b8029e4b88338f0a3',
+  quoterAddress: '0x33e885ed0ec9bf04ecfb19341582aadcb4c8a9e7',
+  nonfungiblePositionManagerAddress: '0x73991a25c818bf1f1128deaab1492d45638de0d3',
+  tickLensAddress: '0x7dfd4f31be6814d2906bde155c3e1b146eac1468',
+  swapRouter02Address: '0xcaf681a66d020601342297493863e78c959e5cb2',
+
+  v4PoolManagerAddress: '0x8366a39cc670b4001a1121b8f6a443a643e40951',
+  v4PositionManagerAddress: '0x58daec3116aae6d93017baaea7749052e8a04fa7',
+  v4StateView: '0xf3334192d15450cdd385c8b70e03f9a6bd9e673b',
+  v4QuoterAddress: '0x8dc178efb8111bb0973dd9d722ebeff267c98f94',
+}
+
 export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses> = {
   [ChainId.MAINNET]: MAINNET_ADDRESSES,
   [ChainId.OPTIMISM]: OPTIMISM_ADDRESSES,
@@ -548,6 +580,8 @@ export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses>
   [ChainId.LINEA]: LINEA_ADDRESSES,
   [ChainId.TEMPO]: TEMPO_ADDRESSES,
   [ChainId.MEGAETH]: MEGAETH_ADDRESSES,
+  [ChainId.ARC]: ARC_ADDRESSES,
+  [ChainId.ROBINHOOD]: ROBINHOOD_ADDRESSES,
 }
 
 /* V3 Contract Addresses */

--- a/sdks/sdk-core/src/chains.test.ts
+++ b/sdks/sdk-core/src/chains.test.ts
@@ -6,6 +6,7 @@ describe('getAverageBlockTimeSecs', () => {
     expect(getAverageBlockTimeSecs(ChainId.ARBITRUM_ONE)).toEqual(0.25)
     expect(getAverageBlockTimeSecs(ChainId.ROBINHOOD)).toEqual(0.1)
     expect(getAverageBlockTimeSecs(ChainId.MEGAETH)).toEqual(1)
+    expect(getAverageBlockTimeSecs(ChainId.ARC)).toEqual(1) // TODO(arc): confirm average block time
   })
 
   it('throws on unregistered chainId', () => {

--- a/sdks/sdk-core/src/chains.ts
+++ b/sdks/sdk-core/src/chains.ts
@@ -35,7 +35,8 @@ export enum ChainId {
   LINEA = 59144,
   TEMPO = 4217,
   MEGAETH = 4326,
-  ROBINHOOD = 46630,
+  ARC = 5042,
+  ROBINHOOD = 4663,
 }
 
 /**
@@ -64,6 +65,7 @@ export const AVERAGE_BLOCK_TIMES_SECONDS: { [chainId: number]: number } = {
   [ChainId.XLAYER]: 1,
   [ChainId.TEMPO]: 0.5,
   [ChainId.MEGAETH]: 1,
+  [ChainId.ARC]: 1, // TODO(arc): confirm average block time from explorer.arc.io
   [ChainId.ROBINHOOD]: 0.1,
 }
 
@@ -124,6 +126,8 @@ export const SUPPORTED_CHAINS = [
   ChainId.LINEA,
   ChainId.TEMPO,
   ChainId.MEGAETH,
+  ChainId.ARC,
+  ChainId.ROBINHOOD,
 ] as const
 export type SupportedChainsType = (typeof SUPPORTED_CHAINS)[number]
 

--- a/sdks/sdk-core/src/entities/weth9.ts
+++ b/sdks/sdk-core/src/entities/weth9.ts
@@ -36,4 +36,7 @@ export const WETH9: { [chainId: number]: Token } = {
   143: new Token(143, '0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A', 18, 'WMON', 'Wrapped Monad'),
   59144: new Token(59144, '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f', 18, 'WETH', 'Wrapped Ether'),
   4326: new Token(4326, '0x4200000000000000000000000000000000000006', 18, 'WETH', 'Wrapped Ether'),
+  // Arc's native currency is USDC; this is the wrapped-native token used in Arc's contract deployments.
+  5042: new Token(5042, '0x8bceaa40b9acdfaedf85adf4ff01f5ad6517937f', 18, 'WETH', 'Wrapped Ether'),
+  4663: new Token(4663, '0x0bd7d308f8e1639fab988df18a8011f41eacad73', 18, 'WETH', 'Wrapped Ether'),
 }

--- a/sdks/universal-router-sdk/src/utils/constants.ts
+++ b/sdks/universal-router-sdk/src/utils/constants.ts
@@ -522,6 +522,34 @@ export const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     },
     swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,
   },
+  // arc (native currency is USDC; weth is the wrapped-native used in Arc's contract deployments)
+  [5042]: {
+    weth: '0x8bceaa40b9acdfaedf85adf4ff01f5ad6517937f',
+    routerConfigs: {
+      [UniversalRouterVersion.V2_1_1]: {
+        address: '0x4fca4a51ab4f23a7447b3284fbd7d73289a89fb1',
+        // TODO(arc): backfill exact UR creation block from explorer.arc.io (deploy tx
+        // 0xf07bb4c6eaccb5b7e128625b0c4fc6bc79f727f9b647a6e81a886bde905345b8). Placeholder 1 is a
+        // conservative scan lower-bound (never misses events, just less efficient).
+        creationBlock: 1,
+      },
+    },
+    swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,
+  },
+  // robinhood
+  [4663]: {
+    weth: '0x0bd7d308f8e1639fab988df18a8011f41eacad73',
+    routerConfigs: {
+      [UniversalRouterVersion.V2_1_1]: {
+        address: '0x8876789976decbfcbbbe364623c63652db8c0904',
+        // TODO(robinhood): backfill exact UR creation block from the Robinhood explorer (deploy tx
+        // 0x422569c99e80a452d45680fbf16cf04cd4ae79cd2b0d7a6a89cf6603009ed1fa). Placeholder 1 is a
+        // conservative scan lower-bound (never misses events, just less efficient).
+        creationBlock: 1,
+      },
+    },
+    swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,
+  },
   // xlayer
   [196]: {
     weth: '0xe538905cf8410324e03A5A23C1c177a474D59b2b',

--- a/sdks/universal-router-sdk/test/utils/constants.test.ts
+++ b/sdks/universal-router-sdk/test/utils/constants.test.ts
@@ -40,6 +40,16 @@ describe('Universal Router Constants', () => {
       expect(() => UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, 4326)).to.throw(
         'Universal Router version 1.2 not deployed on chain 4326'
       )
+
+      // Arc (5042) only has V2_1_1
+      expect(() => UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, 5042)).to.throw(
+        'Universal Router version 1.2 not deployed on chain 5042'
+      )
+
+      // Robinhood (4663) only has V2_1_1
+      expect(() => UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, 4663)).to.throw(
+        'Universal Router version 1.2 not deployed on chain 4663'
+      )
     })
   })
 
@@ -71,6 +81,16 @@ describe('Universal Router Constants', () => {
       // MegaETH (4326) has no V1_2
       expect(() => UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V1_2, 4326)).to.throw(
         'Universal Router version 1.2 not deployed on chain 4326'
+      )
+
+      // Arc (5042) only has V2_1_1
+      expect(() => UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V1_2, 5042)).to.throw(
+        'Universal Router version 1.2 not deployed on chain 5042'
+      )
+
+      // Robinhood (4663) only has V2_1_1
+      expect(() => UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V1_2, 4663)).to.throw(
+        'Universal Router version 1.2 not deployed on chain 4663'
       )
     })
   })


### PR DESCRIPTION
## Description

Adds deployment-address support for two new chains — **Robinhood (4663)** and **Arc (5042)** — across `sdk-core` and `universal-router-sdk`, so routing and Universal Router usage work on them. Mirrors the MegaETH pattern from #585.

Address data sourced from `Uniswap/contracts` deployments (`4663.md`, `5042.md`) and UniRoute's hardcoded chain configs.

## Changes

### sdk-core
- **`chains.ts`**: corrected `ChainId.ROBINHOOD` from `46630` → **`4663`** (matches the canonical Robinhood mainnet chain ID used in the Uniswap backend `config.ts`, `unirpc-v2`, the `CHAIN_ROBINHOOD` proto, and `contracts/deployments/4663.md`); added `ARC = 5042`; added both to `SUPPORTED_CHAINS`; registered Arc's average block time.
- **`addresses.ts`**: added Robinhood/Arc to `V2_FACTORY_ADDRESSES` and `V2_ROUTER_ADDRESSES`; added `ARC_ADDRESSES` and `ROBINHOOD_ADDRESSES` (`ChainAddresses` with the full V2/V3/V4 set); registered both in `CHAIN_TO_ADDRESSES_MAP`. All derived maps (quoter, multicall, tick lens, NPM, swap router 02, v3 factory) auto-populate.
- **`entities/weth9.ts`**: added wrapped-native entries for `4663` (`0x0bd7d308…`) and `5042` (`0x8bceaa40…`). Arc's native currency is USDC; the `5042` entry is the wrapped-native token used in Arc's on-chain contract deployments.

### universal-router-sdk
- **`constants.ts`**: added `CHAIN_CONFIGS[4663]` and `CHAIN_CONFIGS[5042]`, each with the V2_1_1 Universal Router and `swapProxy`.

## How Has This Been Tested?

- `bun run --filter @uniswap/sdk-core test` → **372 pass** (was 370).
- `bun run --filter @uniswap/sdk-core build` → typecheck/build clean (confirms both chains satisfy `Record<SupportedChainsType, ChainAddresses>`).
- `hardhat test test/utils/constants.test.ts` in `universal-router-sdk` → **162 passing** (was 154), covering UR address/creationBlock for 4663 and 5042 and the `V1_2`-not-deployed throws. (Hardhat then emits the same benign `relative URL without a base` post-test error noted in #585.)

## ⚠️ Values to backfill before merge

The chain explorers are auth-gated and these chains have no public RPC, so three values are **placeholders** marked with `TODO` + the deploy tx hash:

1. **Robinhood UR `creationBlock`** — placeholder `1`; deploy tx `0x422569c99e80a452d45680fbf16cf04cd4ae79cd2b0d7a6a89cf6603009ed1fa`
2. **Arc UR `creationBlock`** — placeholder `1`; deploy tx `0xf07bb4c6eaccb5b7e128625b0c4fc6bc79f727f9b647a6e81a886bde905345b8`
3. **Arc `AVERAGE_BLOCK_TIMES_SECONDS`** — placeholder `1`; confirm from `explorer.arc.io`

Placeholder `1` is a conservative scan lower-bound (never misses events, just less efficient).

## Are there any breaking changes?

`ChainId.ROBINHOOD` value changes `46630` → `4663`. Robinhood had no addresses wired up previously, so this is shipped as a **minor** bump (consistent with how MegaETH was shipped).

## Follow-ups

After publish, `trading` and `uniroute` need to bump the sdks version so they align on the correct UR deployed addresses (used for pulling Permit2). Routing review requested in #routing-private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)