### PR TITLE
fix(chains): fix Arc and Robinhood chain constants

### DIFF
--- a/sdks/sdk-core/src/chains.test.ts
+++ b/sdks/sdk-core/src/chains.test.ts
@@ -6,7 +6,7 @@ describe('getAverageBlockTimeSecs', () => {
     expect(getAverageBlockTimeSecs(ChainId.ARBITRUM_ONE)).toEqual(0.25)
     expect(getAverageBlockTimeSecs(ChainId.ROBINHOOD)).toEqual(0.1)
     expect(getAverageBlockTimeSecs(ChainId.MEGAETH)).toEqual(1)
-    expect(getAverageBlockTimeSecs(ChainId.ARC)).toEqual(1) // TODO(arc): confirm average block time
+    expect(getAverageBlockTimeSecs(ChainId.ARC)).toEqual(0.48)
   })
 
   it('throws on unregistered chainId', () => {
@@ -20,6 +20,8 @@ describe('secondsToBlocks', () => {
     expect(secondsToBlocks(8, ChainId.ARBITRUM_ONE)).toEqual(32) // ceil(8/0.25)
     expect(secondsToBlocks(8, ChainId.TEMPO)).toEqual(16) // ceil(8/0.5)
     expect(secondsToBlocks(8, ChainId.MEGAETH)).toEqual(8) // ceil(8/1)
+    expect(secondsToBlocks(8, ChainId.ARC)).toEqual(17) // ceil(8/0.48)
+    expect(secondsToBlocks(8, ChainId.ROBINHOOD)).toEqual(80) // ceil(8/0.1)
     expect(secondsToBlocks(1, ChainId.MAINNET)).toEqual(1) // ceil(1/12) — rounds up to a full block
   })
 

--- a/sdks/sdk-core/src/chains.ts
+++ b/sdks/sdk-core/src/chains.ts
@@ -65,7 +65,7 @@ export const AVERAGE_BLOCK_TIMES_SECONDS: { [chainId: number]: number } = {
   [ChainId.XLAYER]: 1,
   [ChainId.TEMPO]: 0.5,
   [ChainId.MEGAETH]: 1,
-  [ChainId.ARC]: 1, // TODO(arc): confirm average block time from explorer.arc.io
+  [ChainId.ARC]: 0.48,
   [ChainId.ROBINHOOD]: 0.1,
 }
 

--- a/sdks/sdk-core/src/entities/ether.test.ts
+++ b/sdks/sdk-core/src/entities/ether.test.ts
@@ -14,4 +14,10 @@ describe('Ether', () => {
   it('#equals returns true for same chains', () => {
     expect(Ether.onChain(1).equals(Ether.onChain(1))).toEqual(true)
   })
+  it('#wrapped returns Robinhood WETH', () => {
+    expect(Ether.onChain(4663).wrapped.address).toEqual('0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73')
+  })
+  it('#wrapped throws for Arc because WETH is unsupported', () => {
+    expect(() => Ether.onChain(5042).wrapped).toThrow('WRAPPED')
+  })
 })

--- a/sdks/sdk-core/src/entities/weth9.ts
+++ b/sdks/sdk-core/src/entities/weth9.ts
@@ -36,7 +36,5 @@ export const WETH9: { [chainId: number]: Token } = {
   143: new Token(143, '0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A', 18, 'WMON', 'Wrapped Monad'),
   59144: new Token(59144, '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f', 18, 'WETH', 'Wrapped Ether'),
   4326: new Token(4326, '0x4200000000000000000000000000000000000006', 18, 'WETH', 'Wrapped Ether'),
-  // Arc's native currency is USDC; this is the wrapped-native token used in Arc's contract deployments.
-  5042: new Token(5042, '0x8bceaa40b9acdfaedf85adf4ff01f5ad6517937f', 18, 'WETH', 'Wrapped Ether'),
-  4663: new Token(4663, '0x0bd7d308f8e1639fab988df18a8011f41eacad73', 18, 'WETH', 'Wrapped Ether'),
+  4663: new Token(4663, '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73', 18, 'WETH', 'Wrapped Ether'),
 }

--- a/sdks/universal-router-sdk/src/utils/constants.ts
+++ b/sdks/universal-router-sdk/src/utils/constants.ts
@@ -522,30 +522,24 @@ export const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     },
     swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,
   },
-  // arc (native currency is USDC; weth is the wrapped-native used in Arc's contract deployments)
+  // arc
   [5042]: {
-    weth: '0x8bceaa40b9acdfaedf85adf4ff01f5ad6517937f',
+    weth: WETH_NOT_SUPPORTED_ON_CHAIN,
     routerConfigs: {
       [UniversalRouterVersion.V2_1_1]: {
         address: '0x4fca4a51ab4f23a7447b3284fbd7d73289a89fb1',
-        // TODO(arc): backfill exact UR creation block from explorer.arc.io (deploy tx
-        // 0xf07bb4c6eaccb5b7e128625b0c4fc6bc79f727f9b647a6e81a886bde905345b8). Placeholder 1 is a
-        // conservative scan lower-bound (never misses events, just less efficient).
-        creationBlock: 1,
+        creationBlock: 1950059,
       },
     },
     swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,
   },
   // robinhood
   [4663]: {
-    weth: '0x0bd7d308f8e1639fab988df18a8011f41eacad73',
+    weth: '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73',
     routerConfigs: {
       [UniversalRouterVersion.V2_1_1]: {
         address: '0x8876789976decbfcbbbe364623c63652db8c0904',
-        // TODO(robinhood): backfill exact UR creation block from the Robinhood explorer (deploy tx
-        // 0x422569c99e80a452d45680fbf16cf04cd4ae79cd2b0d7a6a89cf6603009ed1fa). Placeholder 1 is a
-        // conservative scan lower-bound (never misses events, just less efficient).
-        creationBlock: 1,
+        creationBlock: 18127,
       },
     },
     swapProxy: SWAP_PROXY_DEPLOY_ADDRESS,

--- a/sdks/universal-router-sdk/test/utils/constants.test.ts
+++ b/sdks/universal-router-sdk/test/utils/constants.test.ts
@@ -3,6 +3,7 @@ import {
   UniversalRouterVersion,
   UNIVERSAL_ROUTER_ADDRESS,
   UNIVERSAL_ROUTER_CREATION_BLOCK,
+  WETH_ADDRESS,
   CHAIN_CONFIGS,
 } from '../../src/utils/constants'
 
@@ -10,6 +11,7 @@ describe('Universal Router Constants', () => {
   // only the chain numbers that have a router deployed
   const chainIds = Object.keys(CHAIN_CONFIGS).map(Number)
   const versions = Object.keys(CHAIN_CONFIGS[1].routerConfigs) as unknown as UniversalRouterVersion[]
+  const v211OnlyChainIds = [5042, 4663]
 
   describe('UNIVERSAL_ROUTER_ADDRESS', () => {
     versions.forEach((version) => {
@@ -41,14 +43,23 @@ describe('Universal Router Constants', () => {
         'Universal Router version 1.2 not deployed on chain 4326'
       )
 
-      // Arc (5042) only has V2_1_1
-      expect(() => UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, 5042)).to.throw(
-        'Universal Router version 1.2 not deployed on chain 5042'
-      )
+      // Arc (5042) and Robinhood (4663) only have V2_1_1
+      v211OnlyChainIds.forEach((chainId) => {
+        expect(() => UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, chainId)).to.throw(
+          `Universal Router version 1.2 not deployed on chain ${chainId}`
+        )
+        expect(() => UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V2_0, chainId)).to.throw(
+          `Universal Router version 2.0 not deployed on chain ${chainId}`
+        )
+      })
+    })
 
-      // Robinhood (4663) only has V2_1_1
-      expect(() => UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V1_2, 4663)).to.throw(
-        'Universal Router version 1.2 not deployed on chain 4663'
+    it('should return the correct V2_1_1 address for arc and robinhood', () => {
+      expect(UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V2_1_1, 5042)).to.equal(
+        '0x4fca4a51ab4f23a7447b3284fbd7d73289a89fb1'
+      )
+      expect(UNIVERSAL_ROUTER_ADDRESS(UniversalRouterVersion.V2_1_1, 4663)).to.equal(
+        '0x8876789976decbfcbbbe364623c63652db8c0904'
       )
     })
   })
@@ -83,15 +94,30 @@ describe('Universal Router Constants', () => {
         'Universal Router version 1.2 not deployed on chain 4326'
       )
 
-      // Arc (5042) only has V2_1_1
-      expect(() => UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V1_2, 5042)).to.throw(
-        'Universal Router version 1.2 not deployed on chain 5042'
-      )
+      // Arc (5042) and Robinhood (4663) only have V2_1_1
+      v211OnlyChainIds.forEach((chainId) => {
+        expect(() => UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V1_2, chainId)).to.throw(
+          `Universal Router version 1.2 not deployed on chain ${chainId}`
+        )
+        expect(() => UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V2_0, chainId)).to.throw(
+          `Universal Router version 2.0 not deployed on chain ${chainId}`
+        )
+      })
+    })
 
-      // Robinhood (4663) only has V2_1_1
-      expect(() => UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V1_2, 4663)).to.throw(
-        'Universal Router version 1.2 not deployed on chain 4663'
-      )
+    it('should return the correct V2_1_1 creation block for arc and robinhood', () => {
+      expect(UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V2_1_1, 5042)).to.equal(1950059)
+      expect(UNIVERSAL_ROUTER_CREATION_BLOCK(UniversalRouterVersion.V2_1_1, 4663)).to.equal(18127)
+    })
+  })
+
+  describe('WETH_ADDRESS', () => {
+    it('should throw for arc because WETH is unsupported', () => {
+      expect(() => WETH_ADDRESS(5042)).to.throw('Chain 5042 does not have WETH')
+    })
+
+    it('should return Robinhood WETH', () => {
+      expect(WETH_ADDRESS(4663)).to.equal('0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73')
     })
   })
 })


### PR DESCRIPTION
## Description

Corrects the Arc and Robinhood constants that landed in #597 before the pending changeset is released.

## Changes

- Sets Arc average block time to `0.48` seconds.
- Treats Arc as having no IWETH9-compatible wrapped native token:
  - removes `WETH9[5042]`
  - uses `WETH_NOT_SUPPORTED_ON_CHAIN` in the Universal Router config
- Replaces placeholder Universal Router creation blocks with exact deployment blocks:
  - Arc: `1950059`
  - Robinhood: `18127`
- Keeps Robinhood WETH configured as `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73`.
- Adds tests for Arc no-WETH behavior, exact UR addresses/creation blocks, and unsupported UR versions.

## Why

Arc’s deployment used `UnsupportedProtocol` for WETH-like constructor slots. That address should not be exposed as a real WETH9 token because wrap/unwrap paths would be constructed against a contract that intentionally does not support them. This matches the existing Celo/Tempo pattern of using `WETH_NOT_SUPPORTED_ON_CHAIN`.

## Validation

- `git diff --check` passed.
- `sdks/sdk-core/node_modules/typescript/bin/tsc -p sdks/sdk-core/tsconfig.cjs.json --noEmit` passed.

Could not run Bun package tests locally because this shell does not have the `bun` binary installed (`command not found: bun`).