### PR TITLE
feat(universal-router-sdk): add nativeErc20Input option for native-ERC20 gas tokens

### DIFF
--- a/.changeset/native-erc20-input.md
+++ b/.changeset/native-erc20-input.md
@@ -1,0 +1,5 @@
+---
+'@uniswap/universal-router-sdk': minor
+---
+
+Add `nativeErc20Input` swap option for chains whose native gas token is exposed via an ERC20 predeploy (e.g. USDC on Arc). When set, swaps are funded by attaching `msg.value = maximumAmountIn * 10^(18 - token.decimals)` instead of pulling the input via Permit2: the Universal Router self-funds (`payerIsUser = false`), no ERC20 approval or permit is ever needed, and unused input is swept back to the recipient on exact-output / partial-fill-risk trades. Off by default; incompatible with native input, `inputTokenPermit`, and `TokenTransferMode.ApproveProxy`.

--- a/sdks/universal-router-sdk/src/entities/actions/uniswap.ts
+++ b/sdks/universal-router-sdk/src/entities/actions/uniswap.ts
@@ -57,6 +57,15 @@ export enum TokenTransferMode {
 
 export type SwapOptions = Omit<RouterSwapOptions, 'inputTokenPermit'> & {
   useRouterBalance?: boolean
+  /**
+   * The input Token is the chain's native gas token exposed via an ERC20 predeploy whose balance
+   * mirrors the native balance (e.g. USDC on Arc). The swap is funded by attaching
+   * msg.value = maximumAmountIn * 10^(18 - token.decimals) instead of pulling via Permit2:
+   * the router self-funds (payerIsUser = false) and unused input is swept back to the recipient
+   * on exact-output / partial-fill-risk trades. No ERC20 approval or permit is ever needed.
+   * Incompatible with native input, inputTokenPermit, and TokenTransferMode.ApproveProxy.
+   */
+  nativeErc20Input?: boolean
   inputTokenPermit?: Permit2Permit
   flatFee?: FlatFeeOptions
   safeMode?: boolean
@@ -83,6 +92,21 @@ export class UniswapTrade implements Command {
   constructor(public trade: RouterTrade<Currency, Currency, TradeType>, public options: SwapOptions) {
     if (!!options.fee && !!options.flatFee) throw new Error('Only one fee option permitted')
 
+    if (options.nativeErc20Input) {
+      // input token is the chain's native gas token exposed via an ERC20 predeploy (e.g. Arc USDC);
+      // the router is funded by msg.value instead of Permit2, so it pays pools from its own balance
+      if (this.trade.inputAmount.currency.isNative) throw new Error('nativeErc20Input requires an ERC20 input token')
+      if (options.tokenTransferMode === TokenTransferMode.ApproveProxy) {
+        throw new Error('nativeErc20Input is not supported with ApproveProxy')
+      }
+      if (options.inputTokenPermit) throw new Error('nativeErc20Input does not use Permit2; remove inputTokenPermit')
+      if (this.inputRequiresUnwrap) {
+        throw new Error(
+          'nativeErc20Input requires routes quoted against the ERC20 input (native pathInput unsupported)'
+        )
+      }
+    }
+
     if (options.tokenTransferMode === TokenTransferMode.ApproveProxy) {
       if (!options.recipient || options.recipient === SENDER_AS_RECIPIENT) {
         throw new Error(
@@ -90,7 +114,12 @@ export class UniswapTrade implements Command {
         )
       }
       this.payerIsUser = false
-    } else if (this.inputRequiresWrap || this.inputRequiresUnwrap || this.options.useRouterBalance) {
+    } else if (
+      this.inputRequiresWrap ||
+      this.inputRequiresUnwrap ||
+      this.options.useRouterBalance ||
+      this.options.nativeErc20Input
+    ) {
       this.payerIsUser = false
     } else {
       this.payerIsUser = true
@@ -340,6 +369,14 @@ export class UniswapTrade implements Command {
         planner.addCommand(CommandType.WRAP_ETH, [this.options.recipient, CONTRACT_BALANCE])
       } else if (this.options.tokenTransferMode === TokenTransferMode.ApproveProxy) {
         // Proxy pulled maximumAmountIn into the UR; sweep any unused input back to the user
+        planner.addCommand(CommandType.SWEEP, [
+          getCurrencyAddress(this.trade.inputAmount.currency),
+          this.options.recipient,
+          0,
+        ])
+      } else if (this.options.nativeErc20Input) {
+        // msg.value funded the router with maximumAmountIn (native balance == ERC20 balance via predeploy);
+        // sweep any unused input ERC20 back to the user
         planner.addCommand(CommandType.SWEEP, [
           getCurrencyAddress(this.trade.inputAmount.currency),
           this.options.recipient,

--- a/sdks/universal-router-sdk/src/swapRouter.ts
+++ b/sdks/universal-router-sdk/src/swapRouter.ts
@@ -110,9 +110,19 @@ export abstract class SwapRouter {
       }
     }
 
-    const nativeCurrencyValue = inputCurrency.isNative
-      ? BigNumber.from(trade.trade.maximumAmountIn(options.slippageTolerance).quotient.toString())
-      : BigNumber.from(0)
+    let nativeCurrencyValue: BigNumber
+    if (inputCurrency.isNative) {
+      nativeCurrencyValue = BigNumber.from(trade.trade.maximumAmountIn(options.slippageTolerance).quotient.toString())
+    } else if (options.nativeErc20Input) {
+      // input token is the chain's native-ERC20 gas token (e.g. Arc USDC predeploy):
+      // fund the router via msg.value, scaled from token decimals to 18-decimal native units
+      invariant(inputCurrency.decimals <= 18, 'NATIVE_ERC20_INPUT_DECIMALS')
+      nativeCurrencyValue = BigNumber.from(
+        trade.trade.maximumAmountIn(options.slippageTolerance).quotient.toString()
+      ).mul(BigNumber.from(10).pow(18 - inputCurrency.decimals))
+    } else {
+      nativeCurrencyValue = BigNumber.from(0)
+    }
 
     trade.encode(planner, { allowRevert: false })
 

--- a/sdks/universal-router-sdk/src/swapRouter.ts
+++ b/sdks/universal-router-sdk/src/swapRouter.ts
@@ -167,13 +167,14 @@ export abstract class SwapRouter {
     } = normalizedSpec
 
     // Ingress: pull funds into the router. Native input is paid as msg.value at the bottom
-    // instead of via Permit2; ApproveProxy ingress is handled by the outer wrapper at the end.
+    // instead of via Permit2 — as is a native-ERC20 gas-token input (nativeErc20Input);
+    // ApproveProxy ingress is handled by the outer wrapper at the end.
     if (normalizedSpec.tokenTransferMode === TokenTransferMode.Permit2) {
       if (normalizedSpec.permit) {
         encodePermit(planner, normalizedSpec.permit)
       }
 
-      if (!inputToken.isNative) {
+      if (!inputToken.isNative && !normalizedSpec.nativeErc20Input) {
         planner.addCommand(
           CommandType.PERMIT2_TRANSFER_FROM,
           [getCurrencyAddress(inputToken), ROUTER_AS_RECIPIENT, exactOrMaxAmountIn],
@@ -249,7 +250,18 @@ export abstract class SwapRouter {
     }
 
     // Native input pays via msg.value; ERC20 input is already in the router via Permit2.
-    return SwapRouter.encodePlan(planner, inputToken.isNative ? exactOrMaxAmountIn : BigNumber.from(0), {
+    // A native-ERC20 gas-token input (e.g. Arc USDC predeploy) also pays via msg.value,
+    // scaled from token decimals to 18-decimal native units.
+    let nativeCurrencyValue: BigNumber
+    if (inputToken.isNative) {
+      nativeCurrencyValue = exactOrMaxAmountIn
+    } else if (normalizedSpec.nativeErc20Input) {
+      nativeCurrencyValue = exactOrMaxAmountIn.mul(BigNumber.from(10).pow(18 - inputToken.decimals))
+    } else {
+      nativeCurrencyValue = BigNumber.from(0)
+    }
+
+    return SwapRouter.encodePlan(planner, nativeCurrencyValue, {
       deadline: normalizedSpec.deadline ? BigNumber.from(normalizedSpec.deadline) : undefined,
     })
   }

--- a/sdks/universal-router-sdk/src/types/encodeSwaps.ts
+++ b/sdks/universal-router-sdk/src/types/encodeSwaps.ts
@@ -30,6 +30,14 @@ export type SwapSpecification = {
   deadline?: BigNumberish
   urVersion?: UniversalRouterVersion
   safeMode?: boolean // appends a trailing SWEEP(ETH, recipient, 0) to recover native dust or unintended msg.value
+  /**
+   * The input Token is the chain's native gas token exposed via an ERC20 predeploy whose balance
+   * mirrors the native balance (e.g. USDC on Arc). The swap is funded by attaching
+   * msg.value = exactOrMaxAmountIn * 10^(18 - token.decimals) instead of pulling via Permit2:
+   * the PERMIT2_TRANSFER_FROM ingress is skipped and no ERC20 approval or permit is ever needed.
+   * Incompatible with native input, permit, and TokenTransferMode.ApproveProxy.
+   */
+  nativeErc20Input?: boolean
 }
 
 // Output of `normalizeEncodeSwapsSpec`: the four fields below are guaranteed

--- a/sdks/universal-router-sdk/src/utils/validateEncodeSwaps.ts
+++ b/sdks/universal-router-sdk/src/utils/validateEncodeSwaps.ts
@@ -100,6 +100,14 @@ export function validateEncodeSwaps(spec: NormalizedSwapSpecification, swapSteps
   // permit2 is ERC20-only; native input pays via msg.value
   invariant(!(spec.routing.inputToken.isNative && spec.permit), 'NATIVE_INPUT_PERMIT')
 
+  // native-ERC20 gas-token input (e.g. Arc USDC): funded via msg.value, never via Permit2
+  if (spec.nativeErc20Input) {
+    invariant(!spec.routing.inputToken.isNative, 'NATIVE_ERC20_INPUT_NATIVE_TOKEN')
+    invariant(!spec.permit, 'NATIVE_ERC20_INPUT_PERMIT_CONFLICT')
+    invariant(spec.tokenTransferMode !== TokenTransferMode.ApproveProxy, 'NATIVE_ERC20_INPUT_PROXY_CONFLICT')
+    invariant(spec.routing.inputToken.decimals <= 18, 'NATIVE_ERC20_INPUT_DECIMALS')
+  }
+
   // portion fees pair with exact-input (% of variable output); flat fees pair with exact-output (fixed deduction from the target)
   invariant(
     !(spec.fee?.kind === 'portion' && spec.tradeType !== TradeType.EXACT_INPUT),

--- a/sdks/universal-router-sdk/test/unit/encodeSwaps.test.ts
+++ b/sdks/universal-router-sdk/test/unit/encodeSwaps.test.ts
@@ -3,7 +3,7 @@ import { BigNumber, utils } from 'ethers'
 import { defaultAbiCoder } from 'ethers/lib/utils'
 import { Route as V3RouteSDK } from '@uniswap/v3-sdk'
 import { Trade as RouterTrade } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount, Percent, TradeType } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent, Token, TradeType } from '@uniswap/sdk-core'
 import { URVersion, V4BaseActionsParser } from '@uniswap/v4-sdk'
 import { SwapRouter } from '../../src/swapRouter'
 import { TokenTransferMode } from '../../src/entities/actions/uniswap'
@@ -1541,6 +1541,119 @@ describe('encodeSwaps', () => {
           }),
         ])
       ).to.throw('STEP_RECIPIENT_MUST_BE_ROUTER')
+    })
+  })
+
+  describe('nativeErc20Input', () => {
+    // scale from a 6-decimal native-ERC20 (e.g. Arc USDC) to 18-decimal native units
+    const SCALE_6_TO_18 = BigNumber.from(10).pow(12)
+    const TOKEN_20_DECIMALS = new Token(1, '0x1111111111111111111111111111111111111111', 20, 'T20', 'Twenty')
+
+    describe('validateEncodeSwaps', () => {
+      it('rejects native input', () => {
+        const spec = buildSpec(
+          { nativeErc20Input: true },
+          {
+            inputToken: ETH,
+            outputToken: DAI,
+            amount: CurrencyAmount.fromRawAmount(ETH, '1000000000000000000'),
+            quote: CurrencyAmount.fromRawAmount(DAI, '1000000000000000000'),
+          }
+        )
+        expect(() => validateEncodeSwaps(spec, [buildV3ExactInStep({}, [WETH, DAI])])).to.throw(
+          'NATIVE_ERC20_INPUT_NATIVE_TOKEN'
+        )
+      })
+
+      it('rejects a permit', () => {
+        const spec = buildSpec({ nativeErc20Input: true, permit: TEST_PERMIT })
+        expect(() => validateEncodeSwaps(spec, [buildV3ExactInStep()])).to.throw('NATIVE_ERC20_INPUT_PERMIT_CONFLICT')
+      })
+
+      it('rejects ApproveProxy token transfer mode', () => {
+        const spec = buildSpec({
+          nativeErc20Input: true,
+          tokenTransferMode: TokenTransferMode.ApproveProxy,
+          chainId: 1,
+        })
+        expect(() => validateEncodeSwaps(spec, [buildV3ExactInStep()])).to.throw('NATIVE_ERC20_INPUT_PROXY_CONFLICT')
+      })
+
+      it('rejects input tokens with more than 18 decimals', () => {
+        const spec = buildSpec(
+          { nativeErc20Input: true },
+          {
+            inputToken: TOKEN_20_DECIMALS,
+            amount: CurrencyAmount.fromRawAmount(TOKEN_20_DECIMALS, '100000000000000000000'),
+          }
+        )
+        expect(() => validateEncodeSwaps(spec, [buildV3ExactInStep({}, [TOKEN_20_DECIMALS, WETH])])).to.throw(
+          'NATIVE_ERC20_INPUT_DECIMALS'
+        )
+      })
+    })
+
+    describe('SwapRouter.encodeSwaps', () => {
+      it('skips the PERMIT2_TRANSFER_FROM ingress and attaches msg.value scaled from 6 to 18 decimals', () => {
+        const spec = buildSpec({ nativeErc20Input: true })
+        const { calldata, value } = SwapRouter.encodeSwaps(spec, [buildV3ExactInStep()])
+
+        // no ingress pull: the router is funded by msg.value
+        const { commandTypes } = parseCommands(calldata)
+        expect(commandTypes).to.deep.equal([CommandType.V3_SWAP_EXACT_IN, CommandType.SWEEP])
+
+        // exact-input: value is the exact input amount, scaled to native units
+        expect(BigNumber.from(value).toString()).to.equal(BigNumber.from('1000000').mul(SCALE_6_TO_18).toString())
+      })
+
+      it('still refunds unused input and scales the slippage-padded max for exact-output', () => {
+        const spec = buildSpec(
+          { tradeType: TradeType.EXACT_OUTPUT, nativeErc20Input: true },
+          {
+            amount: CurrencyAmount.fromRawAmount(WETH, '500000000000000000'),
+            quote: CurrencyAmount.fromRawAmount(USDC, '1000000'),
+          }
+        )
+        const { calldata, value } = SwapRouter.encodeSwaps(spec, [buildV3ExactOutStep()])
+
+        const { commandTypes, inputs } = parseCommands(calldata)
+        expect(commandTypes).to.deep.equal([CommandType.V3_SWAP_EXACT_OUT, CommandType.SWEEP, CommandType.SWEEP])
+
+        // the unconditional exact-output refund returns the surplus as the input ERC20
+        const refund = defaultAbiCoder.decode(['address', 'address', 'uint256'], inputs[2])
+        expect((refund[0] as string).toLowerCase()).to.equal(USDC.address.toLowerCase())
+        expect((refund[1] as string).toLowerCase()).to.equal(TEST_RECIPIENT.toLowerCase())
+
+        // value covers the slippage-padded maximum input, scaled to native units
+        const maxIn = exactOutputMaxIn(BigNumber.from('1000000'), spec.slippageTolerance)
+        expect(BigNumber.from(value).toString()).to.equal(maxIn.mul(SCALE_6_TO_18).toString())
+      })
+
+      it('uses a scale factor of 1 for an 18-decimal native-ERC20 (Celo-style)', () => {
+        const inputAmount = '1000000000000000000'
+        const spec = buildSpec(
+          { nativeErc20Input: true },
+          {
+            inputToken: DAI,
+            amount: CurrencyAmount.fromRawAmount(DAI, inputAmount),
+          }
+        )
+        const { value } = SwapRouter.encodeSwaps(spec, [buildV3ExactInStep({ amountIn: inputAmount }, [DAI, WETH])])
+
+        expect(BigNumber.from(value).toString()).to.equal(inputAmount)
+      })
+
+      it('leaves behavior unchanged when the flag is not set', () => {
+        const { calldata, value } = SwapRouter.encodeSwaps(buildSpec(), [buildV3ExactInStep()])
+
+        expect(value).to.equal('0x00')
+        const { commandTypes } = parseCommands(calldata)
+        expect(commandTypes).to.deep.equal([
+          CommandType.PERMIT2_TRANSFER_FROM,
+          CommandType.V3_SWAP_EXACT_IN,
+          CommandType.SWEEP,
+        ])
+      })
     })
   })
 

--- a/sdks/universal-router-sdk/test/unit/nativeErc20Input.test.ts
+++ b/sdks/universal-router-sdk/test/unit/nativeErc20Input.test.ts
@@ -1,0 +1,265 @@
+import { expect } from 'chai'
+import { BigNumber } from 'ethers'
+import { defaultAbiCoder } from '@ethersproject/abi'
+import { Trade as V3Trade, Pool as V3Pool, Route as V3Route } from '@uniswap/v3-sdk'
+import { Pool as V4Pool, Route as V4Route, Trade as V4Trade } from '@uniswap/v4-sdk'
+import { Currency, CurrencyAmount, Token, TradeType, Percent } from '@uniswap/sdk-core'
+import { Trade as RouterTrade } from '@uniswap/router-sdk'
+import { SwapRouter } from '../../src/swapRouter'
+import { UniswapTrade, SwapOptions, TokenTransferMode } from '../../src/entities/actions/uniswap'
+import { CommandType } from '../../src/utils/routerCommands'
+import { ETHER, WETH, USDC, makeV3Pool, makeV4Pool, parseCommands } from '../utils/uniswapData'
+
+const TEST_RECIPIENT = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+// V4 planner action ids needed to locate SETTLE params inside a V4_SWAP command
+const V4_ACTION_SETTLE = 0x0b
+
+// scale from a 6-decimal native-ERC20 (e.g. Arc USDC) to 18-decimal native units
+const SCALE_6_TO_18 = BigNumber.from(10).pow(12)
+
+function buildV3Trade(
+  pool: V3Pool,
+  inputCurrency: Token,
+  outputCurrency: Token,
+  inputAmount: string,
+  outputAmount: string,
+  tradeType: TradeType = TradeType.EXACT_INPUT
+): RouterTrade<any, any, TradeType> {
+  const route = new V3Route([pool], inputCurrency, outputCurrency)
+  const trade = V3Trade.createUncheckedTrade({
+    route,
+    inputAmount: CurrencyAmount.fromRawAmount(inputCurrency, inputAmount),
+    outputAmount: CurrencyAmount.fromRawAmount(outputCurrency, outputAmount),
+    tradeType,
+  })
+  return new RouterTrade({
+    v2Routes: [],
+    v3Routes: [
+      {
+        routev3: trade.route,
+        inputAmount: trade.inputAmount,
+        outputAmount: trade.outputAmount,
+      },
+    ],
+    v4Routes: [],
+    mixedRoutes: [],
+    tradeType,
+  })
+}
+
+function buildV4Trade(
+  pool: V4Pool,
+  inputCurrency: Currency,
+  outputCurrency: Currency,
+  inputAmount: string,
+  outputAmount: string,
+  tradeType: TradeType = TradeType.EXACT_INPUT
+): RouterTrade<any, any, TradeType> {
+  const route = new V4Route([pool], inputCurrency, outputCurrency)
+  const trade = V4Trade.createUncheckedTrade({
+    route,
+    inputAmount: CurrencyAmount.fromRawAmount(inputCurrency, inputAmount),
+    outputAmount: CurrencyAmount.fromRawAmount(outputCurrency, outputAmount),
+    tradeType,
+  })
+  return new RouterTrade({
+    v2Routes: [],
+    v3Routes: [],
+    v4Routes: [
+      {
+        routev4: trade.route,
+        inputAmount: trade.inputAmount,
+        outputAmount: trade.outputAmount,
+      },
+    ],
+    mixedRoutes: [],
+    tradeType,
+  })
+}
+
+function nativeErc20SwapOptions(overrides: Partial<SwapOptions> = {}): SwapOptions {
+  return {
+    slippageTolerance: new Percent(5, 100),
+    recipient: TEST_RECIPIENT,
+    nativeErc20Input: true,
+    ...overrides,
+  }
+}
+
+// decode the (recipient, amountIn/Out, amountOutMin/InMax, path, payerIsUser) tuple of a V3 swap command
+function decodeV3SwapCommand(input: string) {
+  return defaultAbiCoder.decode(['address', 'uint256', 'uint256', 'bytes', 'bool'], input)
+}
+
+// decode the (token, recipient, amountMin) tuple of a SWEEP command
+function decodeSweepCommand(input: string) {
+  return defaultAbiCoder.decode(['address', 'address', 'uint256'], input)
+}
+
+// locate and decode the (currency, amount, payerIsUser) SETTLE params inside a V4_SWAP command input
+function decodeV4Settle(input: string) {
+  const [actions, params] = defaultAbiCoder.decode(['bytes', 'bytes[]'], input)
+  const actionsHex = (actions as string).slice(2)
+  for (let i = 0; i * 2 < actionsHex.length; i++) {
+    if (parseInt(actionsHex.slice(i * 2, i * 2 + 2), 16) === V4_ACTION_SETTLE) {
+      return defaultAbiCoder.decode(['address', 'uint256', 'bool'], (params as string[])[i])
+    }
+  }
+  throw new Error('No SETTLE action found in V4_SWAP command')
+}
+
+describe('nativeErc20Input', () => {
+  let USDC_DAI_V3: V3Pool
+  let USDC_DAI_V4: V4Pool
+  let WETH_USDC_V3: V3Pool
+
+  // a USDC-shaped 6-decimal token standing in for a native-ERC20 gas token predeploy (e.g. Arc USDC);
+  // the flag is caller-asserted, so the encoding is chain-agnostic
+  const DAI = new Token(1, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'dai')
+  const TOKEN_20_DECIMALS = new Token(1, '0x1111111111111111111111111111111111111111', 20, 'T20', 'Twenty')
+
+  before(() => {
+    USDC_DAI_V3 = makeV3Pool(USDC, DAI)
+    USDC_DAI_V4 = makeV4Pool(USDC, DAI)
+    WETH_USDC_V3 = makeV3Pool(WETH, USDC)
+  })
+
+  describe('UniswapTrade validation', () => {
+    it('forces payerIsUser to false', () => {
+      const trade = buildV3Trade(USDC_DAI_V3, USDC, DAI, '1000000', '1000000000000000000')
+      const uniTrade = new UniswapTrade(trade, nativeErc20SwapOptions())
+      expect(uniTrade.payerIsUser).to.equal(false)
+    })
+
+    it('throws when input currency is native', () => {
+      const ethUsdcPool = makeV4Pool(ETHER, USDC)
+      const trade = buildV4Trade(ethUsdcPool, ETHER, USDC, '1000000000000000000', '1000000')
+      expect(() => new UniswapTrade(trade, nativeErc20SwapOptions())).to.throw(
+        'nativeErc20Input requires an ERC20 input token'
+      )
+    })
+
+    it('throws with ApproveProxy token transfer mode', () => {
+      const trade = buildV3Trade(USDC_DAI_V3, USDC, DAI, '1000000', '1000000000000000000')
+      expect(
+        () =>
+          new UniswapTrade(
+            trade,
+            nativeErc20SwapOptions({ tokenTransferMode: TokenTransferMode.ApproveProxy, chainId: 1 })
+          )
+      ).to.throw('nativeErc20Input is not supported with ApproveProxy')
+    })
+
+    it('throws when an inputTokenPermit is provided', () => {
+      const trade = buildV3Trade(USDC_DAI_V3, USDC, DAI, '1000000', '1000000000000000000')
+      const opts = nativeErc20SwapOptions({
+        inputTokenPermit: {
+          details: {
+            token: USDC.address,
+            amount: BigNumber.from('1000000') as any,
+            expiration: BigNumber.from(0) as any,
+            nonce: BigNumber.from(0) as any,
+          },
+          spender: '0x0000000000000000000000000000000000000000',
+          sigDeadline: BigNumber.from(0) as any,
+          signature: '0x',
+        },
+      })
+      expect(() => new UniswapTrade(trade, opts)).to.throw('nativeErc20Input does not use Permit2')
+    })
+
+    it('throws when the V4 route is quoted against a native pathInput', () => {
+      const ethUsdcPool = makeV4Pool(ETHER, USDC)
+      const trade = buildV4Trade(ethUsdcPool, WETH, USDC, '1000000000000000000', '1000000')
+      expect(() => new UniswapTrade(trade, nativeErc20SwapOptions())).to.throw(
+        'nativeErc20Input requires routes quoted against the ERC20 input'
+      )
+    })
+  })
+
+  describe('SwapRouter.swapCallParameters', () => {
+    it('attaches msg.value scaled from 6 to 18 decimals for an exactIn V3 swap', () => {
+      const inputAmount = '1000000' // 1 USDC (6 decimals)
+      const trade = buildV3Trade(USDC_DAI_V3, USDC, DAI, inputAmount, '1000000000000000000')
+      const { calldata, value } = SwapRouter.swapCallParameters(trade, nativeErc20SwapOptions())
+
+      // exactIn: maximumAmountIn is the input amount itself
+      expect(BigNumber.from(value).toString()).to.equal(BigNumber.from(inputAmount).mul(SCALE_6_TO_18).toString())
+
+      // exactly one V3 swap command: no WRAP_ETH, no PERMIT2_PERMIT, no Permit2 pull
+      const { commandTypes, inputs } = parseCommands(calldata)
+      expect(commandTypes).to.deep.equal([CommandType.V3_SWAP_EXACT_IN])
+
+      // the router pays the pool from its own msg.value-funded balance
+      const swap = decodeV3SwapCommand(inputs[0])
+      expect(swap[4]).to.equal(false) // payerIsUser
+    })
+
+    it('sweeps unused input back to the recipient for an exactOut V3 swap', () => {
+      const trade = buildV3Trade(USDC_DAI_V3, USDC, DAI, '1000000', '1000000000000000000', TradeType.EXACT_OUTPUT)
+      const opts = nativeErc20SwapOptions()
+      const { calldata, value } = SwapRouter.swapCallParameters(trade, opts)
+
+      const { commandTypes, inputs } = parseCommands(calldata)
+      expect(commandTypes).to.deep.equal([CommandType.V3_SWAP_EXACT_OUT, CommandType.SWEEP])
+
+      // value covers the slippage-padded maximum input, scaled to native units
+      const swap = decodeV3SwapCommand(inputs[0])
+      const amountInMax = swap[2] as BigNumber
+      expect(BigNumber.from(value).toString()).to.equal(amountInMax.mul(SCALE_6_TO_18).toString())
+      expect(swap[4]).to.equal(false) // payerIsUser
+
+      // the surplus is returned as the input ERC20
+      const sweep = decodeSweepCommand(inputs[1])
+      expect((sweep[0] as string).toLowerCase()).to.equal(USDC.address.toLowerCase())
+      expect((sweep[1] as string).toLowerCase()).to.equal(TEST_RECIPIENT)
+    })
+
+    it('settles a V4 swap from the router balance (payerIsUser = false)', () => {
+      const inputAmount = '1000000'
+      const trade = buildV4Trade(USDC_DAI_V4, USDC, DAI, inputAmount, '1000000000000000000')
+      const { calldata, value } = SwapRouter.swapCallParameters(trade, nativeErc20SwapOptions())
+
+      expect(BigNumber.from(value).toString()).to.equal(BigNumber.from(inputAmount).mul(SCALE_6_TO_18).toString())
+
+      const { commandTypes, inputs } = parseCommands(calldata)
+      expect(commandTypes).to.deep.equal([CommandType.V4_SWAP])
+
+      const settle = decodeV4Settle(inputs[0])
+      expect((settle[0] as string).toLowerCase()).to.equal(USDC.address.toLowerCase())
+      expect(settle[2]).to.equal(false) // payerIsUser
+    })
+
+    it('uses a scale factor of 1 for an 18-decimal native-ERC20 (Celo-style)', () => {
+      const inputAmount = '1000000000000000000' // 1 token (18 decimals)
+      const trade = buildV3Trade(WETH_USDC_V3, WETH, USDC, inputAmount, '1000000')
+      const { value } = SwapRouter.swapCallParameters(trade, nativeErc20SwapOptions())
+
+      expect(BigNumber.from(value).toString()).to.equal(inputAmount)
+    })
+
+    it('throws for input tokens with more than 18 decimals', () => {
+      const pool = makeV3Pool(TOKEN_20_DECIMALS, USDC)
+      const trade = buildV3Trade(pool, TOKEN_20_DECIMALS, USDC, '100000000000000000000', '1000000')
+      expect(() => SwapRouter.swapCallParameters(trade, nativeErc20SwapOptions())).to.throw(
+        'NATIVE_ERC20_INPUT_DECIMALS'
+      )
+    })
+
+    it('leaves behavior unchanged when the flag is not set', () => {
+      const trade = buildV3Trade(USDC_DAI_V3, USDC, DAI, '1000000', '1000000000000000000')
+      const uniTrade = new UniswapTrade(trade, nativeErc20SwapOptions({ nativeErc20Input: undefined }))
+      expect(uniTrade.payerIsUser).to.equal(true)
+
+      const { calldata, value } = SwapRouter.swapCallParameters(
+        trade,
+        nativeErc20SwapOptions({ nativeErc20Input: undefined })
+      )
+      expect(value).to.equal('0x00')
+
+      const swap = decodeV3SwapCommand(parseCommands(calldata).inputs[0])
+      expect(swap[4]).to.equal(true) // payerIsUser: pulled from the user via Permit2
+    })
+  })
+})


### PR DESCRIPTION
## Motivation

Some chains expose their **native gas token through an ERC20 predeploy** whose balance mirrors the native balance 1:1. On Arc (chain 5042), USDC is the gas token: the native side is 18 decimals, and a 6-decimal ERC20 interface lives at the `0x3600…0000` predeploy. Arc has no WETH (already `WETH_NOT_SUPPORTED_ON_CHAIN` in this SDK).

Today the SDK can only encode swaps from such a token as a plain ERC20 input, forcing users through a Permit2 approval + permit signature **even though they hold the chain's gas token**. But the Universal Router can handle this without any approval:

1. send the tx with the input attached as `{value}` in native units
2. encode the route against the ERC20 input
3. `payerIsUser = false`, so the router pays pools from its own (msg.value-funded) balance
4. never wrap — the ERC20 interface is directly usable

## What this adds

A new opt-in `SwapOptions` flag, **`nativeErc20Input`**, on the `SwapRouter.swapCallParameters` path:

- tx `value = maximumAmountIn × 10^(18 − token.decimals)` (×10¹² for Arc USDC; ×1 for an 18-decimal case like CELO)
- `payerIsUser = false` on V2/V3 swap commands and the V4 `SETTLE`
- no `WRAP_ETH` or `PERMIT2_PERMIT` commands
- unused input swept back to the recipient (as the ERC20) on exact-output / partial-fill-risk trades, mirroring the existing ApproveProxy refund
- rejects misuse: native input, `inputTokenPermit`, `TokenTransferMode.ApproveProxy`, native-keyed V4 `pathInput`, and tokens with >18 decimals

**Off by default — when the flag is unset every existing code path is unchanged** (the `payerIsUser` branch, value computation, and refund block all fall through identically).

## Validation

- 11 new decode-level unit tests in `test/unit/nativeErc20Input.test.ts` (value scaling, exact command bytes, decoded `payerIsUser` on V3 + V4 `SETTLE`, exact-output sweep, all rejection paths, and a default-off regression case).
- **Validated live on Arc**: this exact encoding runs end-to-end through the Uniswap trading API against Arc — gas estimation and execution succeed, confirming the predeploy credits msg.value into the router's ERC20 balance.
- The forge interop suite is untouched (no new `interop.json` fixtures): a mainnet fork can't execute this path since attached ETH doesn't credit a mainnet ERC20 — the live Arc validation covers execution instead.

## Design note for reviewers

The flag is **caller-asserted** (the integrator declares "this token is the chain's native-ERC20 gas token"), matching the `useRouterBalance` precedent. The alternative is an SDK-owned chain→predeploy map, which is safer against misuse (setting the flag on a normal ERC20 would strand the attached value in the router) at the cost of a hardcoded registry. Happy to switch if a map is preferred.

Changeset included (minor). Context: Arc needs this today, and CELO could adopt the same path (its native token is likewise an ERC20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)