### PR TITLE
fix(universal-router-sdk): sweep nativeErc20Input refunds as native, not ERC20

### DIFF
--- a/.changeset/native-erc20-input-sweep-native.md
+++ b/.changeset/native-erc20-input-sweep-native.md
@@ -1,0 +1,5 @@
+---
+'@uniswap/universal-router-sdk': patch
+---
+
+`nativeErc20Input` exact-output / partial-fill refunds now sweep the leftover input as native (`ETH_ADDRESS`) instead of the ERC20. The router's leftover lives in its native balance (18 decimals); an ERC20 sweep floors to the token's decimals (e.g. 6 for Arc USDC) and can strand sub-decimal dust in the router.

--- a/sdks/universal-router-sdk/src/entities/actions/uniswap.ts
+++ b/sdks/universal-router-sdk/src/entities/actions/uniswap.ts
@@ -374,16 +374,10 @@ export class UniswapTrade implements Command {
           this.options.recipient,
           0,
         ])
-      } else if (this.options.nativeErc20Input) {
-        // msg.value funded the router with maximumAmountIn (native balance == ERC20 balance via predeploy);
-        // sweep any unused input ERC20 back to the user
-        planner.addCommand(CommandType.SWEEP, [
-          getCurrencyAddress(this.trade.inputAmount.currency),
-          this.options.recipient,
-          0,
-        ])
-      } else if (this.trade.inputAmount.currency.isNative) {
-        // must refund extra native currency sent along for native v4 trades (no input transition)
+      } else if (this.options.nativeErc20Input || this.trade.inputAmount.currency.isNative) {
+        // must refund extra native currency sent along (nativeErc20Input or native v4 trades).
+        // For nativeErc20Input the leftover lives in the router's native balance (18 decimals), so
+        // sweep it as native: an ERC20 sweep would floor to the token's decimals and strand dust.
         planner.addCommand(CommandType.SWEEP, [ETH_ADDRESS, this.options.recipient, 0])
       }
     }

--- a/sdks/universal-router-sdk/src/swapRouter.ts
+++ b/sdks/universal-router-sdk/src/swapRouter.ts
@@ -223,10 +223,12 @@ export abstract class SwapRouter {
 
     // Assumes routers already normalized unused input into `routing.inputToken`.
     // Exact-output uses max input, so any unused slippage padding is refunded to the recipient.
+    // For nativeErc20Input the leftover lives in the router's native balance (18 decimals), so
+    // sweep it as native: an ERC20 sweep would floor to the token's decimals and strand dust.
     if (normalizedSpec.tradeType === TradeType.EXACT_OUTPUT) {
       planner.addCommand(
         CommandType.SWEEP,
-        [getCurrencyAddress(inputToken), normalizedSpec.recipient, 0],
+        [normalizedSpec.nativeErc20Input ? ETH_ADDRESS : getCurrencyAddress(inputToken), normalizedSpec.recipient, 0],
         false,
         normalizedSpec.urVersion
       )

--- a/sdks/universal-router-sdk/test/unit/encodeSwaps.test.ts
+++ b/sdks/universal-router-sdk/test/unit/encodeSwaps.test.ts
@@ -1619,9 +1619,10 @@ describe('encodeSwaps', () => {
         const { commandTypes, inputs } = parseCommands(calldata)
         expect(commandTypes).to.deep.equal([CommandType.V3_SWAP_EXACT_OUT, CommandType.SWEEP, CommandType.SWEEP])
 
-        // the unconditional exact-output refund returns the surplus as the input ERC20
+        // the exact-output refund returns the surplus as native (18 decimals): an ERC20 sweep
+        // would floor to the token's decimals and strand dust in the router
         const refund = defaultAbiCoder.decode(['address', 'address', 'uint256'], inputs[2])
-        expect((refund[0] as string).toLowerCase()).to.equal(USDC.address.toLowerCase())
+        expect((refund[0] as string).toLowerCase()).to.equal(ETH_ADDRESS.toLowerCase())
         expect((refund[1] as string).toLowerCase()).to.equal(TEST_RECIPIENT.toLowerCase())
 
         // value covers the slippage-padded maximum input, scaled to native units

--- a/sdks/universal-router-sdk/test/unit/nativeErc20Input.test.ts
+++ b/sdks/universal-router-sdk/test/unit/nativeErc20Input.test.ts
@@ -8,6 +8,7 @@ import { Trade as RouterTrade } from '@uniswap/router-sdk'
 import { SwapRouter } from '../../src/swapRouter'
 import { UniswapTrade, SwapOptions, TokenTransferMode } from '../../src/entities/actions/uniswap'
 import { CommandType } from '../../src/utils/routerCommands'
+import { ETH_ADDRESS } from '../../src/utils/constants'
 import { ETHER, WETH, USDC, makeV3Pool, makeV4Pool, parseCommands } from '../utils/uniswapData'
 
 const TEST_RECIPIENT = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
@@ -210,9 +211,10 @@ describe('nativeErc20Input', () => {
       expect(BigNumber.from(value).toString()).to.equal(amountInMax.mul(SCALE_6_TO_18).toString())
       expect(swap[4]).to.equal(false) // payerIsUser
 
-      // the surplus is returned as the input ERC20
+      // the surplus is returned as native (18 decimals): an ERC20 sweep would floor
+      // to the token's decimals and strand dust in the router
       const sweep = decodeSweepCommand(inputs[1])
-      expect((sweep[0] as string).toLowerCase()).to.equal(USDC.address.toLowerCase())
+      expect((sweep[0] as string).toLowerCase()).to.equal(ETH_ADDRESS.toLowerCase())
       expect((sweep[1] as string).toLowerCase()).to.equal(TEST_RECIPIENT)
     })
 


### PR DESCRIPTION
Follow-up to #608, addressing @hensha256's post-merge review comments ([1](https://github.com/Uniswap/sdks/pull/608#discussion_r3391808140), [2](https://github.com/Uniswap/sdks/pull/608#discussion_r3391812526)):

> this line imo should sweep using `ETH_ADDRESS` (and sweep as native), instead of sweeping the ERC20 balance. On Arc, ERC20 has 6 decimals and Native has 18 decimals so you can end up leaving dust behind in the router if you do not reference the currency with the full 18 decimals.

> you can combine this `else if` with the one below as they should now have the same SWEEP params

## Changes

- **`UniswapTrade.encode()`** — the `nativeErc20Input` exact-output / partial-fill-risk refund branch is merged into the existing native-input branch: both now `SWEEP(ETH_ADDRESS, recipient, 0)`. The router's leftover lives in its 18-decimal native balance; the previous ERC20 sweep floored to the token's decimals (6 on Arc) and could strand sub-decimal dust.
- **`SwapRouter.encodeSwaps()`** — same fix on the parallel path: the exact-output refund sweeps `ETH_ADDRESS` instead of the input ERC20 when `nativeErc20Input` is set (the dust reasoning applies identically there; flagging since the original comments were on the `swapCallParameters` path only).
- Updated the two affected unit tests to assert the native sweep; patch changeset included.

Full unit suite passes (141 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)