### PR TITLE
feat(smart-wallet-sdk): Add Arc and Robinhood smart wallet support

### DIFF
--- a/.changeset/add-arc-robinhood-smart-wallet.md
+++ b/.changeset/add-arc-robinhood-smart-wallet.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/smart-wallet-sdk": patch
+---
+
+Add Arc and Robinhood smart wallet deployment addresses.

--- a/.changeset/add-arc-robinhood-smart-wallet.md
+++ b/.changeset/add-arc-robinhood-smart-wallet.md
@@ -1,5 +1,0 @@
----
-"@uniswap/smart-wallet-sdk": patch
----
-
-Add Arc and Robinhood smart wallet deployment addresses.

--- a/sdks/smart-wallet-sdk/CHANGELOG.md
+++ b/sdks/smart-wallet-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uniswap/smart-wallet-sdk
 
+## 2.6.5
+
+### Patch Changes
+
+- d200b3b: Add Arc and Robinhood smart wallet deployment addresses.
+
 ## 2.6.4
 
 ### Patch Changes

--- a/sdks/smart-wallet-sdk/README.md
+++ b/sdks/smart-wallet-sdk/README.md
@@ -30,6 +30,8 @@ Below is a table of the most recent contract deployment addresses across various
 | Arbitrum One | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
 | Unichain Sepolia | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
 | Sepolia | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
+| Arc | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
+| Robinhood | 0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00 | 35d80918e120d177a49d3d90bcd4dd011caedd32 | v1.0.0 |
 
 ## Documentation
 

--- a/sdks/smart-wallet-sdk/package.json
+++ b/sdks/smart-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-wallet-sdk",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "description": "⚒️ An SDK for building applications with smart wallets on Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/smart-wallet-sdk/src/constants.ts
+++ b/sdks/smart-wallet-sdk/src/constants.ts
@@ -30,6 +30,8 @@ export enum SupportedChainIds {
   BNB = ChainId.BNB,
   ARBITRUM_ONE = ChainId.ARBITRUM_ONE,
   XLAYER = ChainId.XLAYER,
+  ARC = ChainId.ARC,
+  ROBINHOOD = ChainId.ROBINHOOD,
 }
 
 /**
@@ -91,6 +93,14 @@ export const SMART_WALLET_VERSIONS: { [_chainId in SupportedChainIds]: SmartWall
     [SmartWalletVersion.v1_0_0_staging]: '0x3cbad1e3b9049ecdb9588fb48dd61d80faf41bd5',
   },
   [SupportedChainIds.XLAYER]: {
+    [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+    [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+  },
+  [SupportedChainIds.ARC]: {
+    [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+    [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
+  },
+  [SupportedChainIds.ROBINHOOD]: {
     [SmartWalletVersion.LATEST]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
     [SmartWalletVersion.v1_0_0]: '0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00',
   },


### PR DESCRIPTION
## Summary
- Add Arc and Robinhood to the smart wallet SDK supported chain IDs.
- Register the canonical v1.0.0 Calibur deployment address for both chains.
- Document the deployments and add a patch changeset for `@uniswap/smart-wallet-sdk`.

## Test plan
- `bun run --filter @uniswap/smart-wallet-sdk test`
- `bun run --filter @uniswap/smart-wallet-sdk build`