### PR TITLE
feat(uniswapx-sdk): add all new chains to PERMIT2_MAPPING

### DIFF
--- a/.changeset/uniswapx-permit2-new-chains.md
+++ b/.changeset/uniswapx-permit2-new-chains.md
@@ -1,5 +1,0 @@
----
-"@uniswap/uniswapx-sdk": patch
----
-
-Add all remaining supported chains to PERMIT2_MAPPING: Rootstock (30), Gnosis (100), Moonbeam (1284), MegaETH (4326), Robinhood (4663), Arc (5042), Monad Testnet (10143), Linea (59144), Base Sepolia (84532), Arbitrum Sepolia (421614), Optimism Sepolia (11155420), and Zora Sepolia (999999999) at the canonical Permit2 address, plus zkSync Era (324) at its non-canonical address (different create2 derivation).

--- a/.changeset/uniswapx-permit2-new-chains.md
+++ b/.changeset/uniswapx-permit2-new-chains.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/uniswapx-sdk": patch
+---
+
+Add all remaining supported chains to PERMIT2_MAPPING: Rootstock (30), Gnosis (100), Moonbeam (1284), MegaETH (4326), Robinhood (4663), Arc (5042), Monad Testnet (10143), Linea (59144), Base Sepolia (84532), Arbitrum Sepolia (421614), Optimism Sepolia (11155420), and Zora Sepolia (999999999) at the canonical Permit2 address, plus zkSync Era (324) at its non-canonical address (different create2 derivation).

--- a/sdks/uniswapx-sdk/CHANGELOG.md
+++ b/sdks/uniswapx-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uniswap/uniswapx-sdk
 
+## 3.0.8
+
+### Patch Changes
+
+- a9877ce: Add all remaining supported chains to PERMIT2_MAPPING: Rootstock (30), Gnosis (100), Moonbeam (1284), MegaETH (4326), Robinhood (4663), Arc (5042), Monad Testnet (10143), Linea (59144), Base Sepolia (84532), Arbitrum Sepolia (421614), Optimism Sepolia (11155420), and Zora Sepolia (999999999) at the canonical Permit2 address, plus zkSync Era (324) at its non-canonical address (different create2 derivation).
+
 ## 3.0.7
 
 ### Patch Changes

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswapx-sdk",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "author": "Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/uniswapx-sdk/src/constants.ts
+++ b/sdks/uniswapx-sdk/src/constants.ts
@@ -28,22 +28,37 @@ export const PERMIT2_MAPPING: AddressMap = {
     "0x000000000022d473030f116ddee9f6b43ac78ba3",
     [
       11155111, // sepolia
-      10,       // optimism
-      56,       // bnb
-      143,      // monad
-      196,      // xlayer
-      480,      // worldchain
-      1868,     // soneium
-      4217,     // tempo
-      42161,    // arbitrum
-      42220,    // celo
-      43114,    // avalanche
-      81457,    // blast
-      7777777,  // zora
+      10,        // optimism
+      30,        // rootstock
+      56,        // bnb
+      100,       // gnosis
+      143,       // monad
+      196,       // xlayer
+      480,       // worldchain
+      1284,      // moonbeam
+      1868,      // soneium
+      4217,      // tempo
+      4326,      // megaeth
+      4663,      // robinhood
+      5042,      // arc
+      10143,     // monad testnet
+      42161,     // arbitrum
+      42220,     // celo
+      43114,     // avalanche
+      59144,     // linea
+      81457,     // blast
+      84532,     // base sepolia
+      421614,    // arbitrum sepolia
+      7777777,   // zora
+      11155420,  // optimism sepolia
+      999999999, // zora sepolia
     ]
   ),
   12341234: "0x000000000022d473030f116ddee9f6b43ac78ba3",
   1301: "0x000000000022d473030f116ddee9f6b43ac78ba3",
+  // zksync has a different create2 address derivation, so Permit2 lives at a
+  // non-canonical address there (matches permit2-sdk's permit2Address(324))
+  324: "0x0000000000225e31D15943971F47aD3022F714Fa",
 };
 
 export const UNISWAPX_ORDER_QUOTER_MAPPING: AddressMap = {


### PR DESCRIPTION
## Summary

Registers every remaining `@uniswap/sdk-core` chain in `PERMIT2_MAPPING` so UniswapX order construction, nonce management, and quoting work on the newly added chains.

**Added at the canonical Permit2 address (`0x000000000022d473030f116ddee9f6b43ac78ba3`):**

| Chain | ID |
|---|---|
| Rootstock | 30 |
| Gnosis | 100 |
| Moonbeam | 1284 |
| MegaETH | 4326 |
| Robinhood | 4663 |
| Arc | 5042 |
| Monad Testnet | 10143 |
| Linea | 59144 |
| Base Sepolia | 84532 |
| Arbitrum Sepolia | 421614 |
| Optimism Sepolia | 11155420 |
| Zora Sepolia | 999999999 |

**Added at a non-canonical address:** zkSync Era (324) → `0x0000000000225e31D15943971F47aD3022F714Fa`, matching `permit2Address(324)` in `@uniswap/permit2-sdk` (zksync's create2 derivation differs from other EVM chains).

**Intentionally omitted:** decommissioned testnets (Optimism/Arbitrum/Base Goerli, Polygon Mumbai, Celo Alfajores).

## Verification

- Permit2 bytecode confirmed on-chain via `eth_getCode` against public RPCs for every chain with a reachable endpoint (Rootstock, Gnosis, Moonbeam, MegaETH, Linea, zkSync, Monad Testnet, and all four Sepolia testnets).
- Robinhood (4663) and Arc (5042) have no public RPC yet; their Permit2 deployments are confirmed in the [Uniswap/contracts deployment registry](https://github.com/Uniswap/contracts/tree/main/deployments) (`4663.md`, `5042.md`).

## Test plan

- `bun run build:cjs` passes
- `bun test src/` — 318 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)