### PR TITLE
chore(uniswapx-sdk): bump uniswapx-sdk to 3.0.8

### DIFF
--- a/.changeset/uniswapx-permit2-new-chains.md
+++ b/.changeset/uniswapx-permit2-new-chains.md
@@ -1,5 +1,0 @@
----
-"@uniswap/uniswapx-sdk": patch
----
-
-Add all remaining supported chains to PERMIT2_MAPPING: Rootstock (30), Gnosis (100), Moonbeam (1284), MegaETH (4326), Robinhood (4663), Arc (5042), Monad Testnet (10143), Linea (59144), Base Sepolia (84532), Arbitrum Sepolia (421614), Optimism Sepolia (11155420), and Zora Sepolia (999999999) at the canonical Permit2 address, plus zkSync Era (324) at its non-canonical address (different create2 derivation).

--- a/sdks/uniswapx-sdk/CHANGELOG.md
+++ b/sdks/uniswapx-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uniswap/uniswapx-sdk
 
+## 3.0.8
+
+### Patch Changes
+
+- a9877ce: Add all remaining supported chains to PERMIT2_MAPPING: Rootstock (30), Gnosis (100), Moonbeam (1284), MegaETH (4326), Robinhood (4663), Arc (5042), Monad Testnet (10143), Linea (59144), Base Sepolia (84532), Arbitrum Sepolia (421614), Optimism Sepolia (11155420), and Zora Sepolia (999999999) at the canonical Permit2 address, plus zkSync Era (324) at its non-canonical address (different create2 derivation).
+
 ## 3.0.7
 
 ### Patch Changes

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswapx-sdk",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "author": "Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [


### PR DESCRIPTION
## Summary

Bumps `@uniswap/uniswapx-sdk` **3.0.7 → 3.0.8** by consuming the changeset from #612 (`changeset version`):

- `sdks/uniswapx-sdk/package.json` version bump
- CHANGELOG entry for the PERMIT2_MAPPING chain additions
- removes the consumed changeset file

## Notes

- Stacked on #612 (`uniswapx-permit2-new-chains`); GitHub will retarget this PR to `main` automatically when #612 merges.
- Once this merges to `main` with no changesets remaining, the release workflow publishes 3.0.8 to npm directly (skipping the bot's "Version Packages" PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)