### PR TITLE
fix(universal-router-sdk): decode minHopPriceX36 in calldata parser

### DIFF
--- a/.changeset/calldata-decoder-min-hop-slippage.md
+++ b/.changeset/calldata-decoder-min-hop-slippage.md
@@ -1,0 +1,5 @@
+---
+'@uniswap/universal-router-sdk': patch
+---
+
+Fix `CommandParser.parseCalldata` to decode the `minHopPriceX36` per-hop slippage parameter added in UniversalRouter V2.1.1. The decoder now accepts an optional `UniversalRouterVersion` (defaulting to `V2_0` for backwards compatibility) and uses the V2.1.1 V2/V3 swap command definitions plus the versioned V4 action parser so the trailing `minHopPriceX36` array is no longer silently dropped.

--- a/sdks/universal-router-sdk/src/utils/commandParser.ts
+++ b/sdks/universal-router-sdk/src/utils/commandParser.ts
@@ -1,8 +1,16 @@
 import { ethers } from 'ethers'
 import UniversalRouter from '@uniswap/universal-router/artifacts/contracts/UniversalRouter.sol/UniversalRouter.json'
 import { Interface } from '@ethersproject/abi'
-import { V4BaseActionsParser, V4RouterAction } from '@uniswap/v4-sdk'
-import { CommandType, CommandDefinition, COMMAND_DEFINITION, Subparser, Parser } from '../utils/routerCommands'
+import { URVersion, V4BaseActionsParser, V4RouterAction } from '@uniswap/v4-sdk'
+import {
+  CommandType,
+  CommandDefinition,
+  COMMAND_DEFINITION,
+  V2V3_SWAP_COMMANDS_V2_1_1,
+  Subparser,
+  Parser,
+} from '../utils/routerCommands'
+import { UniversalRouterVersion, isAtLeastV2_1_1 } from '../utils/constants'
 
 export type Param = {
   readonly name: string
@@ -33,8 +41,16 @@ export interface CommandsDefinition {
 export abstract class CommandParser {
   public static INTERFACE: Interface = new Interface(UniversalRouter.abi)
 
-  public static parseCalldata(calldata: string): UniversalRouterCall {
-    const genericParser = new GenericCommandParser(COMMAND_DEFINITION)
+  public static parseCalldata(
+    calldata: string,
+    urVersion: UniversalRouterVersion = UniversalRouterVersion.V2_0
+  ): UniversalRouterCall {
+    // From V2.1.1 onwards the V2/V3 swap commands carry an extra minHopPriceX36 array,
+    // so the matching command definitions must be used to decode them correctly.
+    const commandDefinition = isAtLeastV2_1_1(urVersion)
+      ? { ...COMMAND_DEFINITION, ...V2V3_SWAP_COMMANDS_V2_1_1 }
+      : COMMAND_DEFINITION
+    const genericParser = new GenericCommandParser(commandDefinition, urVersion)
     const txDescription = CommandParser.INTERFACE.parseTransaction({ data: calldata })
     const { commands, inputs } = txDescription.args
     return genericParser.parse(commands, inputs)
@@ -43,7 +59,10 @@ export abstract class CommandParser {
 
 // Parses commands based on given command definition
 export class GenericCommandParser {
-  constructor(private readonly commandDefinition: CommandsDefinition) {}
+  constructor(
+    private readonly commandDefinition: CommandsDefinition,
+    private readonly urVersion: UniversalRouterVersion = UniversalRouterVersion.V2_0
+  ) {}
 
   public parse(commands: string, inputs: string[]): UniversalRouterCall {
     const commandTypes = GenericCommandParser.getCommands(commands)
@@ -53,7 +72,8 @@ export class GenericCommandParser {
         const commandDef = this.commandDefinition[commandType]
 
         if (commandDef.parser === Parser.V4Actions) {
-          const { actions } = V4BaseActionsParser.parseCalldata(inputs[i])
+          // UniversalRouterVersion and URVersion share identical string values; cast across the SDK boundary
+          const { actions } = V4BaseActionsParser.parseCalldata(inputs[i], this.urVersion as unknown as URVersion)
           return {
             commandName: CommandType[commandType],
             commandType,

--- a/sdks/universal-router-sdk/test/utils/commandParser.test.ts
+++ b/sdks/universal-router-sdk/test/utils/commandParser.test.ts
@@ -1,11 +1,14 @@
 import { expect } from 'chai'
-import { Token, WETH9 } from '@uniswap/sdk-core'
+import { Token, WETH9, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { encodeSqrtRatioX96, nearestUsableTick, TickMath } from '@uniswap/v3-sdk'
 import { ethers, BigNumber } from 'ethers'
-import { CommandParser, UniversalRouterCall } from '../../src/utils/commandParser'
+import { CommandParser, Param, UniversalRouterCall } from '../../src/utils/commandParser'
 import { RoutePlanner, CommandType } from '../../src/utils/routerCommands'
+import { UniversalRouterVersion } from '../../src/utils/constants'
 import { SwapRouter } from '../../src/swapRouter'
-import { V4Planner, Actions, Pool } from '@uniswap/v4-sdk'
+import { V4Planner, Actions, Pool, Route as V4Route, Trade as V4Trade } from '@uniswap/v4-sdk'
+import { Trade as RouterTrade } from '@uniswap/router-sdk'
+import { WETH, USDC as USDC_DATA, DAI, makeV4Pool, swapOptions } from './uniswapData'
 
 const addressOne = '0x0000000000000000000000000000000000000001'
 const addressTwo = '0x0000000000000000000000000000000000000002'
@@ -39,6 +42,7 @@ describe('Command Parser', () => {
   type ParserTest = {
     input: RoutePlanner
     result: UniversalRouterCall
+    version?: UniversalRouterVersion
   }
 
   const tests: ParserTest[] = [
@@ -273,6 +277,110 @@ describe('Command Parser', () => {
         ],
       },
     },
+    // V2.1.1 V3 exact-in carries the trailing minHopPriceX36 array and must round-trip through the decoder
+    {
+      version: UniversalRouterVersion.V2_1_1,
+      input: new RoutePlanner().addCommand(
+        CommandType.V3_SWAP_EXACT_IN,
+        [addressOne, amount, amount, encodePathExactInput([addressOne, addressTwo], 123), true, ['500', '600']],
+        false,
+        UniversalRouterVersion.V2_1_1
+      ),
+      result: {
+        commands: [
+          {
+            commandName: 'V3_SWAP_EXACT_IN',
+            commandType: CommandType.V3_SWAP_EXACT_IN,
+            params: [
+              { name: 'recipient', value: addressOne },
+              { name: 'amountIn', value: amount },
+              { name: 'amountOutMin', value: amount },
+              { name: 'path', value: [{ tokenIn: addressOne, tokenOut: addressTwo, fee: 123 }] },
+              { name: 'payerIsUser', value: true },
+              { name: 'minHopPriceX36', value: [BigNumber.from(500), BigNumber.from(600)] },
+            ],
+          },
+        ],
+      },
+    },
+    // V2.1.1 V3 exact-out
+    {
+      version: UniversalRouterVersion.V2_1_1,
+      input: new RoutePlanner().addCommand(
+        CommandType.V3_SWAP_EXACT_OUT,
+        [addressOne, amount, amount, encodePathExactOutput([addressOne, addressTwo], 123), true, ['750']],
+        false,
+        UniversalRouterVersion.V2_1_1
+      ),
+      result: {
+        commands: [
+          {
+            commandName: 'V3_SWAP_EXACT_OUT',
+            commandType: CommandType.V3_SWAP_EXACT_OUT,
+            params: [
+              { name: 'recipient', value: addressOne },
+              { name: 'amountOut', value: amount },
+              { name: 'amountInMax', value: amount },
+              { name: 'path', value: [{ tokenIn: addressOne, tokenOut: addressTwo, fee: 123 }] },
+              { name: 'payerIsUser', value: true },
+              { name: 'minHopPriceX36', value: [BigNumber.from(750)] },
+            ],
+          },
+        ],
+      },
+    },
+    // V2.1.1 V2 exact-in
+    {
+      version: UniversalRouterVersion.V2_1_1,
+      input: new RoutePlanner().addCommand(
+        CommandType.V2_SWAP_EXACT_IN,
+        [addressOne, amount, amount, [addressOne, addressTwo], true, ['500', '600']],
+        false,
+        UniversalRouterVersion.V2_1_1
+      ),
+      result: {
+        commands: [
+          {
+            commandName: 'V2_SWAP_EXACT_IN',
+            commandType: CommandType.V2_SWAP_EXACT_IN,
+            params: [
+              { name: 'recipient', value: addressOne },
+              { name: 'amountIn', value: amount },
+              { name: 'amountOutMin', value: amount },
+              { name: 'path', value: [addressOne, addressTwo] },
+              { name: 'payerIsUser', value: true },
+              { name: 'minHopPriceX36', value: [BigNumber.from(500), BigNumber.from(600)] },
+            ],
+          },
+        ],
+      },
+    },
+    // V2.1.1 V2 exact-out
+    {
+      version: UniversalRouterVersion.V2_1_1,
+      input: new RoutePlanner().addCommand(
+        CommandType.V2_SWAP_EXACT_OUT,
+        [addressOne, amount, amount, [addressOne, addressTwo], true, ['250']],
+        false,
+        UniversalRouterVersion.V2_1_1
+      ),
+      result: {
+        commands: [
+          {
+            commandName: 'V2_SWAP_EXACT_OUT',
+            commandType: CommandType.V2_SWAP_EXACT_OUT,
+            params: [
+              { name: 'recipient', value: addressOne },
+              { name: 'amountOut', value: amount },
+              { name: 'amountInMax', value: amount },
+              { name: 'path', value: [addressOne, addressTwo] },
+              { name: 'payerIsUser', value: true },
+              { name: 'minHopPriceX36', value: [BigNumber.from(250)] },
+            ],
+          },
+        ],
+      },
+    },
     {
       input: new RoutePlanner().addCommand(CommandType.V4_SWAP, [
         new V4Planner()
@@ -418,11 +526,76 @@ describe('Command Parser', () => {
       const functionSignature = 'execute(bytes,bytes[])'
       const calldata = SwapRouter.INTERFACE.encodeFunctionData(functionSignature, [commands, inputs])
 
-      const result = CommandParser.parseCalldata(calldata)
+      const result = CommandParser.parseCalldata(calldata, test.version)
       // Normalize BigNumbers in both objects for comparison
       expect(normalizeBigNumbers(result)).to.deep.equal(normalizeBigNumbers(test.result))
     })
   }
+
+  // V4 swaps are delegated to V4BaseActionsParser; the V2.1.1 minHopPriceX36 lives inside the
+  // swap action struct, so verify it survives a full round-trip through CommandParser.
+  describe('V4 per-hop slippage (V2.1.1)', () => {
+    const WETH_USDC_V4 = makeV4Pool(WETH, USDC_DATA)
+    const USDC_DAI_V4 = makeV4Pool(USDC_DATA, DAI)
+
+    it('surfaces minHopPriceX36 in the decoded V4_SWAP action', () => {
+      const v4Route = new V4Route([WETH_USDC_V4, USDC_DAI_V4], WETH, DAI)
+      const v4Trade = V4Trade.createUncheckedTrade({
+        route: v4Route,
+        inputAmount: CurrencyAmount.fromRawAmount(WETH, '1000000000000000000'),
+        outputAmount: CurrencyAmount.fromRawAmount(DAI, '1000000000000000000'),
+        tradeType: TradeType.EXACT_INPUT,
+      })
+      const trade = new RouterTrade({
+        v4Routes: [
+          {
+            routev4: v4Trade.route,
+            inputAmount: v4Trade.inputAmount,
+            outputAmount: v4Trade.outputAmount,
+            minHopPriceX36: [BigInt(1000), BigInt(2000)],
+          },
+        ],
+        tradeType: TradeType.EXACT_INPUT,
+      })
+
+      const { calldata } = SwapRouter.swapCallParameters(
+        trade,
+        swapOptions({ urVersion: UniversalRouterVersion.V2_1_1 })
+      )
+
+      const result = CommandParser.parseCalldata(calldata, UniversalRouterVersion.V2_1_1)
+      const v4Command = result.commands.find((c) => c.commandType === CommandType.V4_SWAP)
+      expect(v4Command, 'expected a V4_SWAP command').to.not.be.undefined
+
+      const swapAction = v4Command!.params.find((p) => p.name === 'SWAP_EXACT_IN')
+      expect(swapAction, 'expected a SWAP_EXACT_IN action').to.not.be.undefined
+
+      const swapStruct = (swapAction!.value as Param[]).find((p) => p.name === 'swap')!.value as any
+      expect(swapStruct.minHopPriceX36.map((v: BigNumber) => v.toString())).to.deep.equal(['1000', '2000'])
+    })
+
+    it('omits minHopPriceX36 when decoding the same V4 swap as V2_0', () => {
+      const v4Route = new V4Route([WETH_USDC_V4, USDC_DAI_V4], WETH, DAI)
+      const v4Trade = V4Trade.createUncheckedTrade({
+        route: v4Route,
+        inputAmount: CurrencyAmount.fromRawAmount(WETH, '1000000000000000000'),
+        outputAmount: CurrencyAmount.fromRawAmount(DAI, '1000000000000000000'),
+        tradeType: TradeType.EXACT_INPUT,
+      })
+      const trade = new RouterTrade({
+        v4Routes: [{ routev4: v4Trade.route, inputAmount: v4Trade.inputAmount, outputAmount: v4Trade.outputAmount }],
+        tradeType: TradeType.EXACT_INPUT,
+      })
+
+      const { calldata } = SwapRouter.swapCallParameters(trade, swapOptions({ urVersion: UniversalRouterVersion.V2_0 }))
+
+      const result = CommandParser.parseCalldata(calldata, UniversalRouterVersion.V2_0)
+      const v4Command = result.commands.find((c) => c.commandType === CommandType.V4_SWAP)!
+      const swapAction = v4Command.params.find((p) => p.name === 'SWAP_EXACT_IN')!
+      const swapStruct = (swapAction.value as Param[]).find((p) => p.name === 'swap')!.value as any
+      expect(swapStruct.minHopPriceX36).to.be.undefined
+    })
+  })
 })
 
 function encodePath(path: string[], fee: number): string {


### PR DESCRIPTION
## Summary

The UniversalRouter calldata decoder (`CommandParser.parseCalldata`) was never updated when UniversalRouter **V2.1.1** added the per-hop slippage parameter (`minHopPriceX36`) to the V2/V3/V4 swap commands. The encoder side (`createCommand` / `RoutePlanner` / `V2V3_SWAP_COMMANDS_V2_1_1`) already supported it, but the decoder:

- always used the base `COMMAND_DEFINITION` (no `minHopPriceX36` on V2/V3 swaps), and
- called `V4BaseActionsParser.parseCalldata` **without a version**, defaulting to V2.0.

As a result, the trailing `minHopPriceX36` array was **silently dropped** when decoding V2.1.1+ calldata, for V2, V3, and V4 swaps alike.

## Fix

`CommandParser.parseCalldata(calldata, urVersion?)` now takes an optional `UniversalRouterVersion` (defaulting to `V2_0`, fully backwards compatible). When the version is ≥ V2.1.1 it:

- merges `V2V3_SWAP_COMMANDS_V2_1_1` over `COMMAND_DEFINITION` so V2/V3 swaps decode the extra `uint256[] minHopPriceX36`, and
- threads the version into `V4BaseActionsParser.parseCalldata`, so V4 swap actions surface `minHopPriceX36` (which lives inside the swap action struct).

Existing callers that pass no version are unaffected.

## Tests

- V2/V3 exact-in & exact-out with `minHopPriceX36` round-trip through the decoder.
- V4 swap surfaces `minHopPriceX36` through a full `CommandParser` round-trip.
- V2.0 backward-compatibility guard (V4 swap decoded as V2.0 omits `minHopPriceX36`).

Full `universal-router-sdk` hardhat suite: **490 passing**. Prettier clean, `tsc` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LafBoef4WdcezNGoPwYHnN