### PR TITLE
chore(codeowners): apps-lp owns liquidity-launcher-sdk version bumps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,8 @@ sdks/v4-sdk/ @Uniswap/swap-be
 # Last match wins — allows swap-be to approve version-only changes
 **/package.json @Uniswap/swap-be
 **/CHANGELOG.md @Uniswap/swap-be
+
+# Teams that own their own version bumps (last match wins, so these override the
+# repo-wide version-file rules above for their package only).
+sdks/liquidity-launcher-sdk/package.json @Uniswap/apps-lp
+sdks/liquidity-launcher-sdk/CHANGELOG.md @Uniswap/apps-lp


### PR DESCRIPTION
## Why

The Changesets "Version Packages" PR for `@uniswap/liquidity-launcher-sdk` (e.g. #619) requests **@Uniswap/swap-be** review instead of the package's owner, **@Uniswap/apps-lp**.

Cause: CODEOWNERS is **last-match-wins**, and the repo-wide version-file rules

```
**/package.json  @Uniswap/swap-be
**/CHANGELOG.md  @Uniswap/swap-be
```

come *after* `sdks/liquidity-launcher-sdk/ @Uniswap/apps-lp`, so they win for the only files a version-bump PR touches (`package.json` + `CHANGELOG.md`). apps-lp ends up unable to self-approve its own release PRs.

## Fix

Append package-scoped overrides **after** the repo-wide rules so they're the last match for this package's version files only:

```
sdks/liquidity-launcher-sdk/package.json  @Uniswap/apps-lp
sdks/liquidity-launcher-sdk/CHANGELOG.md  @Uniswap/apps-lp
```

Every other package keeps the swap-be version-file ownership. Once merged, #619 (and all future liquidity-launcher-sdk version bumps) re-evaluate to require **apps-lp**, not swap-be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)