### PR TITLE
feat(liquidity-launcher-sdk): add avalanche, xlayer, robinhood

### DIFF
--- a/.changeset/launcher-sdk-avax-xlayer-robinhood.md
+++ b/.changeset/launcher-sdk-avax-xlayer-robinhood.md
@@ -2,4 +2,4 @@
 "@uniswap/liquidity-launcher-sdk": minor
 ---
 
-Add Avalanche (43114), XLayer (196), and Robinhood Chain (4663) to the supported launch chains. Avalanche and XLayer launch with pre-existing tokens only (no token factory deployed); Robinhood carries the uERC20 factory. Robinhood is intentionally omitted from `BLOCK_TIME_SECONDS_BY_CHAIN` — like Arbitrum, its contract-visible `block.number` tracks Ethereum L1 (~12s).
+Add Avalanche (43114), XLayer (196), and Robinhood Chain (4663) to the supported launch chains, all carrying the canonical uERC20 factory. Robinhood is intentionally omitted from `BLOCK_TIME_SECONDS_BY_CHAIN` — like Arbitrum, its contract-visible `block.number` tracks Ethereum L1 (~12s).

--- a/.changeset/launcher-sdk-avax-xlayer-robinhood.md
+++ b/.changeset/launcher-sdk-avax-xlayer-robinhood.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/liquidity-launcher-sdk": minor
+---
+
+Add Avalanche (43114), XLayer (196), and Robinhood Chain (4663) to the supported launch chains. Avalanche and XLayer launch with pre-existing tokens only (no token factory deployed); Robinhood carries the uERC20 factory. Robinhood is intentionally omitted from `BLOCK_TIME_SECONDS_BY_CHAIN` — like Arbitrum, its contract-visible `block.number` tracks Ethereum L1 (~12s).

--- a/sdks/liquidity-launcher-sdk/src/addresses.test.ts
+++ b/sdks/liquidity-launcher-sdk/src/addresses.test.ts
@@ -19,6 +19,18 @@ describe('getLauncherAddresses', () => {
   it('returns undefined for an unsupported chain', () => {
     expect(getLauncherAddresses(999999)).toBeUndefined()
   })
+
+  it('returns the per-chain LBPStrategy singletons for the 2026-07 launch chains', () => {
+    expect(getLauncherAddresses(SupportedChainId.AVALANCHE)?.lbpStrategy).toBe(
+      getAddress('0xcacd77134b072b4ad5621f585b0b422c6da4e000')
+    )
+    expect(getLauncherAddresses(SupportedChainId.XLAYER)?.lbpStrategy).toBe(
+      getAddress('0x95bcb80e3804a085d23778f2956c305d6488e000')
+    )
+    expect(getLauncherAddresses(SupportedChainId.ROBINHOOD)?.lbpStrategy).toBe(
+      getAddress('0x095e38a2135aebcffa98a5b6911591937f912000')
+    )
+  })
 })
 
 describe('selectTokenFactory', () => {
@@ -30,5 +42,10 @@ describe('selectTokenFactory', () => {
   it('falls back to the super-uERC20 factory (Unichain)', () => {
     const addresses = getLauncherAddresses(SupportedChainId.UNICHAIN)!
     expect(selectTokenFactory(addresses)).toEqual({ factory: addresses.usuperc20Factory!, kind: 'usuperc20' })
+  })
+
+  it('returns undefined when the chain deploys neither factory (Avalanche)', () => {
+    const addresses = getLauncherAddresses(SupportedChainId.AVALANCHE)!
+    expect(selectTokenFactory(addresses)).toBeUndefined()
   })
 })

--- a/sdks/liquidity-launcher-sdk/src/addresses.test.ts
+++ b/sdks/liquidity-launcher-sdk/src/addresses.test.ts
@@ -44,8 +44,14 @@ describe('selectTokenFactory', () => {
     expect(selectTokenFactory(addresses)).toEqual({ factory: addresses.usuperc20Factory!, kind: 'usuperc20' })
   })
 
-  it('returns undefined when the chain deploys neither factory (Avalanche)', () => {
+  it('selects the uERC20 factory on the 2026-07 launch chains', () => {
     const addresses = getLauncherAddresses(SupportedChainId.AVALANCHE)!
-    expect(selectTokenFactory(addresses)).toBeUndefined()
+    expect(selectTokenFactory(addresses)).toEqual({ factory: addresses.uerc20Factory!, kind: 'uerc20' })
+  })
+
+  it('returns undefined when a chain deploys neither factory', () => {
+    const { uerc20Factory: _u, usuperc20Factory: _s, ...withoutFactories } =
+      getLauncherAddresses(SupportedChainId.ROBINHOOD)!
+    expect(selectTokenFactory(withoutFactories)).toBeUndefined()
   })
 })

--- a/sdks/liquidity-launcher-sdk/src/addresses.ts
+++ b/sdks/liquidity-launcher-sdk/src/addresses.ts
@@ -18,8 +18,9 @@ export interface LauncherAddresses {
   permit2: Address
   /**
    * Registered token factories the new-token path may target. Ethereum-style chains carry a uERC20
-   * factory; superchains carry a super-uERC20 factory. A chain has at least one (mainnet has both);
-   * both are optional so superchain-only and Ethereum-only chains can each omit the one they lack.
+   * factory; superchains carry a super-uERC20 factory (mainnet has both). Both are optional: chains
+   * that deploy neither support launches with pre-existing tokens only ({@link selectTokenFactory}
+   * returns `undefined` there).
    */
   uerc20Factory?: Address
   usuperc20Factory?: Address
@@ -47,6 +48,9 @@ const POSITION_MANAGER_MAINNET = getAddress('0xbD216513d74C8cf14cf4747E6AaA6420F
 const POSITION_MANAGER_UNICHAIN = getAddress('0x4529A01c7A0410167c5740C487A8DE60232617bf')
 const POSITION_MANAGER_BASE = getAddress('0x7C5f5A4bBd8fD63184577525326123B519429bDc')
 const POSITION_MANAGER_ARBITRUM = getAddress('0xd88F38F930b7952f2DB2432Cb002E7abbF3dD869')
+const POSITION_MANAGER_AVALANCHE = getAddress('0xB74b1F14d2754AcfcbBe1a221023a5cf50Ab8ACD')
+const POSITION_MANAGER_XLAYER = getAddress('0xcF1EAFC6928dC385A342E7C6491d371d2871458b')
+const POSITION_MANAGER_ROBINHOOD = getAddress('0x58daec3116aae6D93017bAAea7749052E8a04fA7')
 const POSITION_MANAGER_SEPOLIA = getAddress('0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4')
 const POSITION_MANAGER_BASE_SEPOLIA = getAddress('0x4B2C77d209D3405F41a037Ec6c77F7F5b8e2ca80')
 
@@ -88,6 +92,31 @@ export const LAUNCHER_ADDRESSES: Partial<Record<number, LauncherAddresses>> = {
     permit2: PERMIT2,
     uerc20Factory: UERC20_FACTORY,
     positionManager: POSITION_MANAGER_ARBITRUM,
+  },
+  [SupportedChainId.AVALANCHE]: {
+    liquidityLauncher: LIQUIDITY_LAUNCHER,
+    lbpStrategy: getAddress('0xcAcd77134b072b4AD5621f585b0b422C6Da4E000'),
+    tokenSplitter: TOKEN_SPLITTER,
+    ccaFactory: CCA_FACTORY,
+    permit2: PERMIT2,
+    positionManager: POSITION_MANAGER_AVALANCHE,
+  },
+  [SupportedChainId.XLAYER]: {
+    liquidityLauncher: LIQUIDITY_LAUNCHER,
+    lbpStrategy: getAddress('0x95bcb80e3804a085d23778F2956c305d6488e000'),
+    tokenSplitter: TOKEN_SPLITTER,
+    ccaFactory: CCA_FACTORY,
+    permit2: PERMIT2,
+    positionManager: POSITION_MANAGER_XLAYER,
+  },
+  [SupportedChainId.ROBINHOOD]: {
+    liquidityLauncher: LIQUIDITY_LAUNCHER,
+    lbpStrategy: getAddress('0x095e38a2135aeBcfFa98A5B6911591937f912000'),
+    tokenSplitter: TOKEN_SPLITTER,
+    ccaFactory: CCA_FACTORY,
+    permit2: PERMIT2,
+    uerc20Factory: UERC20_FACTORY,
+    positionManager: POSITION_MANAGER_ROBINHOOD,
   },
   [SupportedChainId.SEPOLIA]: {
     liquidityLauncher: LIQUIDITY_LAUNCHER,

--- a/sdks/liquidity-launcher-sdk/src/addresses.ts
+++ b/sdks/liquidity-launcher-sdk/src/addresses.ts
@@ -99,6 +99,7 @@ export const LAUNCHER_ADDRESSES: Partial<Record<number, LauncherAddresses>> = {
     tokenSplitter: TOKEN_SPLITTER,
     ccaFactory: CCA_FACTORY,
     permit2: PERMIT2,
+    uerc20Factory: UERC20_FACTORY,
     positionManager: POSITION_MANAGER_AVALANCHE,
   },
   [SupportedChainId.XLAYER]: {
@@ -107,6 +108,7 @@ export const LAUNCHER_ADDRESSES: Partial<Record<number, LauncherAddresses>> = {
     tokenSplitter: TOKEN_SPLITTER,
     ccaFactory: CCA_FACTORY,
     permit2: PERMIT2,
+    uerc20Factory: UERC20_FACTORY,
     positionManager: POSITION_MANAGER_XLAYER,
   },
   [SupportedChainId.ROBINHOOD]: {

--- a/sdks/liquidity-launcher-sdk/src/chains.ts
+++ b/sdks/liquidity-launcher-sdk/src/chains.ts
@@ -8,6 +8,9 @@ export enum SupportedChainId {
   UNICHAIN = 130,
   BASE = 8453,
   ARBITRUM_ONE = 42161,
+  AVALANCHE = 43114,
+  XLAYER = 196,
+  ROBINHOOD = 4663,
   SEPOLIA = 11155111,
   BASE_SEPOLIA = 84532,
 }

--- a/sdks/liquidity-launcher-sdk/src/constants.ts
+++ b/sdks/liquidity-launcher-sdk/src/constants.ts
@@ -66,14 +66,17 @@ export const DEFAULT_BLOCK_TIME_SECONDS = 12
 
 /**
  * Approximate block time (seconds) per chain, used to convert auction start/end times to blocks.
- * Chains without an entry fall back to {@link DEFAULT_BLOCK_TIME_SECONDS}. Arbitrum is intentionally
- * omitted: its `block.number` tracks the L1 block cadence (~12s), which the default already matches.
+ * Chains without an entry fall back to {@link DEFAULT_BLOCK_TIME_SECONDS}. Arbitrum and Robinhood
+ * (an Arbitrum Orbit chain) are intentionally omitted: their contract-visible `block.number` tracks
+ * the Ethereum L1 block cadence (~12s), which the default already matches.
  */
 export const BLOCK_TIME_SECONDS_BY_CHAIN: Record<number, number> = {
   1: 12, // mainnet
   130: 1, // unichain
+  196: 1, // xlayer
   1301: 1, // unichain sepolia
   8453: 2, // base
+  43114: 1, // avalanche
   84532: 2, // base sepolia
   11155111: 12, // sepolia
 }


### PR DESCRIPTION
## What

Adds three launch chains to `@uniswap/liquidity-launcher-sdk` (minor bump via changeset):

| chain | id | lbpStrategy | token factory | positionManager | block time |
|---|---|---|---|---|---|
| Avalanche | 43114 | `0xcAcd77134b072b4AD5621f585b0b422C6Da4E000` | uERC20 `0x000000e2…d49b` | `0xB74b…8ACD` | 1s (measured 1.03–1.10s over 2mo) |
| XLayer | 196 | `0x95bcb80e3804a085d23778F2956c305d6488e000` | uERC20 `0x000000e2…d49b` | `0xcF1E…458b` | 1s (exact) |
| Robinhood Chain | 4663 | `0x095e38a2135aeBcfFa98A5B6911591937f912000` | uERC20 `0x000000e2…d49b` | `0x58da…4fA7` | omitted — Orbit chain, contract `block.number` tracks Ethereum L1 (~12s default), same as arbitrum |

## Verification

- LBPStrategy + canonical stack addresses `eth_getCode`-verified on-chain (bytecode sizes match known deployments). Sources: liquidity-launcher README/Parameters.sol, CCA README, on-chain checks. The avalanche/xlayer uERC20 factory deploys are in flight at the canonical address (robinhood's is verified live, 13380B).
- positionManager values match sdk-core `CHAIN_TO_ADDRESSES_MAP[id].v4PositionManagerAddress` (all three chains have `v4StateView` too, so `getFeeTierAvailability` works).
- Robinhood L1-tracking `block.number` confirmed empirically via Multicall3 `getBlockNumber()` (contract sees ~25.49M ≈ Ethereum head; RPC blocks tick ~0.1s).
- `selectTokenFactory`'s neither-factory branch keeps test coverage via a synthetic entry; `LauncherAddresses` doc updated for that case.
- `bun run build` + `bun test` (35/35) + `bun run typecheck` green.

Part of the avalanche/xlayer/robinhood CCA launch (substreams side: Uniswap/substreams#507; runbook: substreams `.claude/skills/add-cca-chains`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)