### PR TITLE
fix(liquidity-launcher-sdk): correct L2 block time for Arbitrum One + Robinhood

### DIFF
--- a/.changeset/launcher-sdk-arb-block-times.md
+++ b/.changeset/launcher-sdk-arb-block-times.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/liquidity-launcher-sdk": patch
+---
+
+Fix auction duration on Arbitrum-family chains. `BLOCK_TIME_SECONDS_BY_CHAIN` now sets the correct sub-second L2 (`arbBlockNumber`) cadence for Arbitrum One (0.25s) and Robinhood (0.1s); previously both fell back to the 12s default, which compressed an auction's real-time window by ~48x (Arbitrum) and ~120x (Robinhood) because the CCA advances on the L2 block clock, not `block.number`. Robinhood additionally requires the on-chain `blocknumberish` library to recognize its chain id (and a CCA/LBPStrategy redeploy) before the fix takes effect on-chain.

--- a/sdks/liquidity-launcher-sdk/src/config/blocks.test.ts
+++ b/sdks/liquidity-launcher-sdk/src/config/blocks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 
 import { SupportedChainId } from '../chains'
 import { DEFAULT_BLOCK_TIME_SECONDS } from '../constants'
+
 import { deriveBlocks, getBlockTimeSeconds } from './blocks'
 
 describe('getBlockTimeSeconds', () => {

--- a/sdks/liquidity-launcher-sdk/src/config/blocks.test.ts
+++ b/sdks/liquidity-launcher-sdk/src/config/blocks.test.ts
@@ -38,7 +38,7 @@ describe('deriveBlocks — real-time auction window is honored', () => {
       nowUnix: NOW,
       blockTimeSeconds: getBlockTimeSeconds(SupportedChainId.ROBINHOOD),
     })
-    // 50400s / 0.1s = 504000 blocks. At the wrong 12s default this was 4200 blocks (~7min real time).
+    // 50400s / 0.1s = 504000 blocks; the 12s default would yield only 4200 (~7min of real time).
     expect(endBlock - startBlock).toBe(504_000n)
   })
 
@@ -50,7 +50,7 @@ describe('deriveBlocks — real-time auction window is honored', () => {
       nowUnix: NOW,
       blockTimeSeconds: getBlockTimeSeconds(SupportedChainId.ARBITRUM_ONE),
     })
-    // 50400s / 0.25s = 201600 blocks (was 4200 → ~17min real time at the 12s default).
+    // 50400s / 0.25s = 201600 blocks; the 12s default would yield only 4200 (~17min of real time).
     expect(endBlock - startBlock).toBe(201_600n)
   })
 })

--- a/sdks/liquidity-launcher-sdk/src/config/blocks.test.ts
+++ b/sdks/liquidity-launcher-sdk/src/config/blocks.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test'
+
+import { SupportedChainId } from '../chains'
+import { DEFAULT_BLOCK_TIME_SECONDS } from '../constants'
+import { deriveBlocks, getBlockTimeSeconds } from './blocks'
+
+describe('getBlockTimeSeconds', () => {
+  it('uses the sub-second L2 cadence for Arbitrum-family chains, not the 12s default', () => {
+    // The CCA advances on blocknumberish._getBlockNumberish(), which is arbBlockNumber (L2) on
+    // these chains — far faster than 12s. Falling back to the default silently shortens auctions.
+    expect(getBlockTimeSeconds(SupportedChainId.ARBITRUM_ONE)).toBe(0.25)
+    expect(getBlockTimeSeconds(SupportedChainId.ROBINHOOD)).toBe(0.1)
+    expect(getBlockTimeSeconds(SupportedChainId.ARBITRUM_ONE)).toBeLessThan(DEFAULT_BLOCK_TIME_SECONDS)
+    expect(getBlockTimeSeconds(SupportedChainId.ROBINHOOD)).toBeLessThan(DEFAULT_BLOCK_TIME_SECONDS)
+  })
+
+  it('keeps the expected cadence for the other launch chains and defaults unknown chains', () => {
+    expect(getBlockTimeSeconds(SupportedChainId.MAINNET)).toBe(12)
+    expect(getBlockTimeSeconds(SupportedChainId.BASE)).toBe(2)
+    expect(getBlockTimeSeconds(SupportedChainId.AVALANCHE)).toBe(1)
+    expect(getBlockTimeSeconds(SupportedChainId.XLAYER)).toBe(1)
+    expect(getBlockTimeSeconds(999_999)).toBe(DEFAULT_BLOCK_TIME_SECONDS)
+  })
+})
+
+describe('deriveBlocks — real-time auction window is honored', () => {
+  const NOW = 1_000_000n
+  const CURRENT_BLOCK = 5_000_000n
+  const start = NOW + 3600n // +1h
+  const end = start + 50_400n // 14h window
+
+  it('spans a 14h auction as ~14h of blocks on Robinhood (regression: was ~7min at the 12s default)', () => {
+    const { startBlock, endBlock } = deriveBlocks({
+      startTimeUnix: start,
+      endTimeUnix: end,
+      currentBlock: CURRENT_BLOCK,
+      nowUnix: NOW,
+      blockTimeSeconds: getBlockTimeSeconds(SupportedChainId.ROBINHOOD),
+    })
+    // 50400s / 0.1s = 504000 blocks. At the wrong 12s default this was 4200 blocks (~7min real time).
+    expect(endBlock - startBlock).toBe(504_000n)
+  })
+
+  it('spans a 14h auction correctly on Arbitrum One', () => {
+    const { startBlock, endBlock } = deriveBlocks({
+      startTimeUnix: start,
+      endTimeUnix: end,
+      currentBlock: CURRENT_BLOCK,
+      nowUnix: NOW,
+      blockTimeSeconds: getBlockTimeSeconds(SupportedChainId.ARBITRUM_ONE),
+    })
+    // 50400s / 0.25s = 201600 blocks (was 4200 → ~17min real time at the 12s default).
+    expect(endBlock - startBlock).toBe(201_600n)
+  })
+})

--- a/sdks/liquidity-launcher-sdk/src/constants.ts
+++ b/sdks/liquidity-launcher-sdk/src/constants.ts
@@ -70,8 +70,8 @@ export const DEFAULT_BLOCK_TIME_SECONDS = 12
  * `blocknumberish._getBlockNumberish()`, which returns the L2 `arbBlockNumber` on Arbitrum-family
  * chains and `block.number` everywhere else — because the range is derived from the same
  * `eth_blockNumber` (L2 sequencer) height the backend reads. A wrong value scales the auction's
- * real-time window by (real cadence / assumed cadence): the old 12s default silently compressed a
- * 14h auction to ~17min on Arbitrum and ~7min on Robinhood.
+ * real-time window by (real cadence / assumed cadence) — e.g. the 12s default would silently
+ * compress a 14h auction to ~17min on Arbitrum and ~7min on Robinhood.
  *
  * Arbitrum One and Robinhood are Arbitrum L2s whose block clock ticks sub-second, so they need
  * explicit entries. NOTE: Robinhood is an Orbit chain where `block.number` diverges from its L2

--- a/sdks/liquidity-launcher-sdk/src/constants.ts
+++ b/sdks/liquidity-launcher-sdk/src/constants.ts
@@ -65,17 +65,29 @@ export const DEFAULT_CONVEXITY_ALPHA = 1.2
 export const DEFAULT_BLOCK_TIME_SECONDS = 12
 
 /**
- * Approximate block time (seconds) per chain, used to convert auction start/end times to blocks.
- * Chains without an entry fall back to {@link DEFAULT_BLOCK_TIME_SECONDS}. Arbitrum and Robinhood
- * (an Arbitrum Orbit chain) are intentionally omitted: their contract-visible `block.number` tracks
- * the Ethereum L1 block cadence (~12s), which the default already matches.
+ * Approximate block time (seconds) per chain, used to convert an auction's start/end times into a
+ * block range. This MUST match the cadence of the clock the CCA advances on —
+ * `blocknumberish._getBlockNumberish()`, which returns the L2 `arbBlockNumber` on Arbitrum-family
+ * chains and `block.number` everywhere else — because the range is derived from the same
+ * `eth_blockNumber` (L2 sequencer) height the backend reads. A wrong value scales the auction's
+ * real-time window by (real cadence / assumed cadence): the old 12s default silently compressed a
+ * 14h auction to ~17min on Arbitrum and ~7min on Robinhood.
+ *
+ * Arbitrum One and Robinhood are Arbitrum L2s whose block clock ticks sub-second, so they need
+ * explicit entries. NOTE: Robinhood is an Orbit chain where `block.number` diverges from its L2
+ * height; the on-chain `blocknumberish` library only substitutes `arbBlockNumber` for Arbitrum
+ * One's chain id today, so Robinhood's CCA/LBPStrategy must be redeployed against a blocknumberish
+ * that also recognizes Robinhood before this value takes effect — keep Robinhood launches gated
+ * until then. Chains without an entry fall back to {@link DEFAULT_BLOCK_TIME_SECONDS}.
  */
 export const BLOCK_TIME_SECONDS_BY_CHAIN: Record<number, number> = {
   1: 12, // mainnet
   130: 1, // unichain
   196: 1, // xlayer
   1301: 1, // unichain sepolia
+  4663: 0.1, // robinhood (arbitrum orbit) — L2 arbBlockNumber cadence; needs blocknumberish support on-chain
   8453: 2, // base
+  42161: 0.25, // arbitrum one — L2 arbBlockNumber cadence (NOT the L1 block.number ~12s)
   43114: 1, // avalanche
   84532: 2, // base sepolia
   11155111: 12, // sepolia

--- a/sdks/liquidity-launcher-sdk/src/constants.ts
+++ b/sdks/liquidity-launcher-sdk/src/constants.ts
@@ -79,6 +79,10 @@ export const DEFAULT_BLOCK_TIME_SECONDS = 12
  * One's chain id today, so Robinhood's CCA/LBPStrategy must be redeployed against a blocknumberish
  * that also recognizes Robinhood before this value takes effect — keep Robinhood launches gated
  * until then. Chains without an entry fall back to {@link DEFAULT_BLOCK_TIME_SECONDS}.
+ *
+ * Values are approximate by nature (a chain's real cadence drifts), and non-integer entries like
+ * `0.1` aren't exactly representable in IEEE-754 — both are absorbed by `deriveBlocks`, which
+ * `Math.round`s the block delta (at most ±1 block, far below the cadence-estimate error itself).
  */
 export const BLOCK_TIME_SECONDS_BY_CHAIN: Record<number, number> = {
   1: 12, // mainnet


### PR DESCRIPTION
## The bug

An auction's start/end **times** are converted to a **block range** via `deriveBlocks` + `getBlockTimeSeconds(chainId)`. That block time must match the cadence of the clock the CCA contract advances on — `blocknumberish._getBlockNumberish()`, which returns the **L2 `arbBlockNumber`** on Arbitrum-family chains and `block.number` elsewhere — because the range is derived from the same `eth_blockNumber` (L2 sequencer) height the backend reads.

**Arbitrum One (42161)** and **Robinhood (4663)** had no entry in `BLOCK_TIME_SECONDS_BY_CHAIN`, so they fell back to the **12s default**. Their real L2 cadence is **~0.25s** and **~0.1s**, so the block span was 48×/120× too small — a 14h auction ran ~17min / ~7min in real time.

Confirmed live: a Robinhood launch (`0xC5EdF109…`) had `endBlock − startBlock = 4200` = exactly `50400s ÷ 12s`, and concluded almost immediately.

## The fix

Add the correct sub-second L2 cadences:

| chain | was | now |
|---|---|---|
| Arbitrum One (42161) | 12s (default) | **0.25s** |
| Robinhood (4663) | 12s (default) | **0.1s** |

Plus `config/blocks.test.ts` asserting the values and a regression that a 14h window derives 201,600 blocks (Arbitrum) / 504,000 (Robinhood) instead of 4,200. Corrected the stale comment that claimed these chains track L1 `block.number` at 12s (they use `arbBlockNumber`). Full suite 39/39, typecheck clean.

## ⚠️ Robinhood needs a contract fix too

The on-chain `blocknumberish` library only substitutes `arbBlockNumber` for **Arbitrum One's** chain id; for Robinhood it returns `block.number`, which on that Orbit chain diverges from the L2 height (~25.5M vs ~4.7M) — so the auction blocks (L2 scale) are already far past `block.number` and the auction is **dead on arrival**. This SDK value only takes effect once `blocknumberish` recognizes Robinhood and its CCA/LBPStrategy are redeployed. **Keep Robinhood launches gated until then.** Filed separately with the contracts team.

Bug fix (patch). Consumers (`backend` liquidity service, which calls `getBlockTimeSeconds`) need a bump to the released version to ship it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)