### PR TITLE
fix(liquidity-launcher-sdk): point ccaFactory at the blocknumberish-v1.1.0 redeploy on all chains

### DIFF
--- a/.changeset/ccafactory-blocknumberish-v11-all-chains.md
+++ b/.changeset/ccafactory-blocknumberish-v11-all-chains.md
@@ -1,0 +1,5 @@
+---
+'@uniswap/liquidity-launcher-sdk': patch
+---
+
+Point `ccaFactory` at the blocknumberish-v1.1.0 CCA factory (`0x000000001F26a0044BaA66024e7b6599c61963F8`) on every chain, not just Robinhood. The v3.1.0 LBPStrategy deployments shipped in #632 all create their auctions through this factory (verified on-chain via `LBPStrategy.initializerFactory()` on mainnet, base, unichain, arbitrum, avalanche, xlayer, sepolia, and base-sepolia), but `ccaFactory` was still reporting the legacy factory (`0x00cCa200BF124dBfA848937c553864f4B4CE0632`) for all non-Robinhood chains. Consumers resolving a chain's auction factory from the SDK (e.g. to pick the TickDataLens) now get the address auctions are actually created from. The legacy factory is retained in `AUCTION_FACTORY_DEPLOYMENTS` so historical auctions still resolve.

--- a/sdks/liquidity-launcher-sdk/src/addresses.ts
+++ b/sdks/liquidity-launcher-sdk/src/addresses.ts
@@ -35,10 +35,17 @@ const PERMIT2 = getAddress('0x000000000022D473030F116dDEE9F6B43aC78BA3')
 
 // Deployed at the same CREATE2 address on every supported chain.
 const LIQUIDITY_LAUNCHER = getAddress('0x00004c4ccc709Ef590F7C81102C0689F0263D4e9')
-const CCA_FACTORY = getAddress('0x00cCa200BF124dBfA848937c553864f4B4CE0632')
-// Robinhood-only redeploy (2026-07-09): CCA factory rebuilt against a blocknumberish that also
-// recognizes chain 4663 (the original deployment only substituted arbBlockNumber on Arbitrum One).
-const CCA_FACTORY_ROBINHOOD = getAddress('0x000000001F26a0044BaA66024e7b6599c61963F8')
+// Current CCA factory: the 2026-07-09 redeploy built against blocknumberish v1.1.0, which translates
+// block.number on every chain that needs it (e.g. Arbitrum One and Robinhood/4663 — the earlier
+// factory only handled Arbitrum, so on other translated chains it derived auction block ranges
+// against the wrong clock). Every v3.1.0 LBPStrategy in LAUNCHER_ADDRESSES creates its auction
+// through this factory (verified on-chain via LBPStrategy.initializerFactory()), so it is the
+// ccaFactory for all chains.
+const CCA_FACTORY = getAddress('0x000000001F26a0044BaA66024e7b6599c61963F8')
+// Legacy CCA factory (built against blocknumberish v1.0.x), used by the pre-v3.1.0 strategies.
+// Superseded as the per-chain ccaFactory by CCA_FACTORY above; retained only so the auction-factory
+// registry can still resolve auctions created before the redeploy.
+const CCA_FACTORY_LEGACY = getAddress('0x00cCa200BF124dBfA848937c553864f4B4CE0632')
 const TOKEN_SPLITTER = getAddress('0x8B7DCeb5639DB986FCf86606C74e6300C40FE3cd')
 
 // Token factories, split by token standard. The uERC20 factory shares a CREATE2 address across the
@@ -118,7 +125,7 @@ export const LAUNCHER_ADDRESSES: Partial<Record<number, LauncherAddresses>> = {
     liquidityLauncher: LIQUIDITY_LAUNCHER,
     lbpStrategy: getAddress('0x05d552391067389EE44fec3924157ed33F976000'),
     tokenSplitter: TOKEN_SPLITTER,
-    ccaFactory: CCA_FACTORY_ROBINHOOD,
+    ccaFactory: CCA_FACTORY,
     permit2: PERMIT2,
     uerc20Factory: UERC20_FACTORY,
     positionManager: POSITION_MANAGER_ROBINHOOD,
@@ -195,14 +202,14 @@ export const AUCTION_FACTORY_DEPLOYMENTS: readonly AuctionFactoryDeployment[] = 
     description: 'v2 CCA factory (early test deploy)',
   },
   {
-    factory: CCA_FACTORY,
+    factory: CCA_FACTORY_LEGACY,
     tickDataLens: TICK_DATA_LENS_V2,
-    description: 'v2 CCA factory (contracts v2.0.0, deployed on all supported chains)',
+    description: 'v2 CCA factory (blocknumberish v1.0.x; superseded by the 2026-07-09 redeploy)',
   },
   {
-    factory: CCA_FACTORY_ROBINHOOD,
+    factory: CCA_FACTORY,
     tickDataLens: TICK_DATA_LENS_V2,
-    description: 'v2 CCA factory (2026-07-09 blocknumberish-aware redeploy, contracts v1.1.x)',
+    description: 'v2 CCA factory (2026-07-09 blocknumberish v1.1.0 redeploy; current on all chains)',
   },
 ]
 


### PR DESCRIPTION
## Description

**Before:** `ccaFactory` reports the legacy CCA factory (`0x00cCa200BF124dBfA848937c553864f4B4CE0632`) for every chain except Robinhood.

**After:** `ccaFactory` reports the 2026-07-09 blocknumberish-v1.1.0 redeploy (`0x000000001F26a0044BaA66024e7b6599c61963F8`) for **all** chains.

## Why

#632 moved every chain to the v3.1.0 `LBPStrategy` deployments, but `ccaFactory` was never updated to match. The v3.1.0 strategies create their auctions through the new factory, so the SDK was reporting a factory that no current strategy actually uses.

Verified on-chain via `LBPStrategy.initializerFactory()` on every shipped strategy:

| Chain | v3.1.0 LBPStrategy | `initializerFactory()` |
| --- | --- | --- |
| Mainnet | `0x49380c…6000` | `0x…1F26` |
| Base | `0x34385d…A000` | `0x…1F26` |
| Unichain | `0x298eA0…A000` | `0x…1F26` |
| Arbitrum One | `0x8Af077…E000` | `0x…1F26` |
| Avalanche | `0x57BD0A…6000` | `0x…1F26` |
| XLayer | `0x58DF16…A000` | `0x…1F26` |
| Sepolia | `0x96641d…E000` | `0x…1F26` |
| Base Sepolia | `0xB06428…E000` | `0x…1F26` |

This matters beyond bookkeeping: the legacy factory was built against blocknumberish v1.0.x, which only translated `block.number` on Arbitrum. On other chains that need translation it derived auction block ranges against the wrong clock (the Robinhood case in #628 silently compressed a ~14h window to ~7min). The v1.1.0 redeploy is the correct factory for those chains.

## What changed

- Repoint the `CCA_FACTORY` constant to `0x…1F26`; rename the old address to `CCA_FACTORY_LEGACY`.
- All per-chain `ccaFactory` entries now resolve to `0x…1F26` (Robinhood switches from the old `CCA_FACTORY_ROBINHOOD` constant to the shared `CCA_FACTORY`).
- Keep the legacy factory in `AUCTION_FACTORY_DEPLOYMENTS` (→ `TICK_DATA_LENS_V2`) so auctions created before the redeploy still resolve their lens.

Tests, typecheck, and lint pass; the registry tests already covered both factory addresses.

Downstream: the substreams auctions indexer was fixed to watch both factories in Uniswap/substreams#523 / #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
