### PR TITLE
fix(sdks): include source content in sourcemaps

### DIFF
--- a/.changeset/calm-sourcemaps-include-sources.md
+++ b/.changeset/calm-sourcemaps-include-sources.md
@@ -1,0 +1,15 @@
+---
+"@uniswap/flashtestations-sdk": patch
+"@uniswap/liquidity-launcher-sdk": patch
+"@uniswap/permit2-sdk": patch
+"@uniswap/router-sdk": patch
+"@uniswap/sdk-core": patch
+"@uniswap/smart-wallet-sdk": patch
+"@uniswap/uniswapx-sdk": patch
+"@uniswap/universal-router-sdk": patch
+"@uniswap/v2-sdk": patch
+"@uniswap/v3-sdk": patch
+"@uniswap/v4-sdk": patch
+---
+
+Include source content in generated sourcemaps so downstream tooling can resolve original TypeScript sources from published packages.

--- a/sdks/flashtestations-sdk/tsconfig.base.json
+++ b/sdks/flashtestations-sdk/tsconfig.base.json
@@ -8,6 +8,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/sdks/liquidity-launcher-sdk/tsconfig.base.json
+++ b/sdks/liquidity-launcher-sdk/tsconfig.base.json
@@ -8,6 +8,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/sdks/permit2-sdk/tsconfig.base.json
+++ b/sdks/permit2-sdk/tsconfig.base.json
@@ -8,6 +8,7 @@
       "importHelpers": true,
       "declaration": true,
       "sourceMap": true,
+      "inlineSources": true,
       "strict": true,
       "moduleResolution": "node",
       "resolveJsonModule": true,

--- a/sdks/router-sdk/tsconfig.base.json
+++ b/sdks/router-sdk/tsconfig.base.json
@@ -9,6 +9,7 @@
         "importHelpers": true,
         "declaration": true,
         "sourceMap": true,
+        "inlineSources": true,
         "strict": true,
         "noImplicitAny": true,
         "strictNullChecks": true,

--- a/sdks/sdk-core/tsconfig.base.json
+++ b/sdks/sdk-core/tsconfig.base.json
@@ -9,6 +9,7 @@
         "importHelpers": true,
         "declaration": true,
         "sourceMap": true,
+        "inlineSources": true,
         "strict": true,
         "noImplicitAny": true,
         "strictNullChecks": true,

--- a/sdks/smart-wallet-sdk/tsconfig.base.json
+++ b/sdks/smart-wallet-sdk/tsconfig.base.json
@@ -8,6 +8,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/sdks/uniswapx-sdk/tsconfig.base.json
+++ b/sdks/uniswapx-sdk/tsconfig.base.json
@@ -7,6 +7,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/sdks/universal-router-sdk/tsconfig.base.json
+++ b/sdks/universal-router-sdk/tsconfig.base.json
@@ -9,6 +9,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/sdks/v2-sdk/tsconfig.base.json
+++ b/sdks/v2-sdk/tsconfig.base.json
@@ -9,6 +9,7 @@
         "importHelpers": true,
         "declaration": true,
         "sourceMap": true,
+        "inlineSources": true,
         "strict": true,
         "noImplicitAny": true,
         "strictNullChecks": true,

--- a/sdks/v3-sdk/tsconfig.base.json
+++ b/sdks/v3-sdk/tsconfig.base.json
@@ -9,6 +9,7 @@
         "importHelpers": true,
         "declaration": true,
         "sourceMap": true,
+        "inlineSources": true,
         "strict": true,
         "noImplicitAny": true,
         "strictNullChecks": true,

--- a/sdks/v4-sdk/tsconfig.base.json
+++ b/sdks/v4-sdk/tsconfig.base.json
@@ -9,6 +9,7 @@
         "importHelpers": true,
         "declaration": true,
         "sourceMap": true,
+        "inlineSources": true,
         "strict": true,
         "noImplicitAny": true,
         "strictNullChecks": true,


### PR DESCRIPTION
## PR Scope

This is a packaging/source-map fix across SDK packages that publish compiled TypeScript output.

## Description

The SDK packages currently emit JavaScript sourcemaps, but published npm packages only include `dist`. The generated `.js.map` files reference original TypeScript paths such as `../../../src/index.ts` without embedding `sourcesContent`, so downstream tooling that resolves sourcemaps from the published package can warn that the source files are missing.

This sets `inlineSources: true` alongside `sourceMap: true` for the SDK `tsconfig.base.json` files so generated sourcemaps include the original TypeScript source content. Runtime JavaScript and type declaration output are unchanged; only sourcemap contents change.

## How Has This Been Tested?

- `bun install --frozen-lockfile`
- `bun run g:build`
- `bun run g:lint`
- `bun run g:typecheck`
- Manually inspected generated sourcemaps, including:
  - `sdks/sdk-core/dist/esm/src/index.js.map`
  - `sdks/router-sdk/dist/esm/src/index.js.map`
  - `sdks/universal-router-sdk/dist/esm/src/index.js.map`
  - `sdks/v3-sdk/dist/esm/src/entities/pool.js.map`

Each inspected map now contains `sourcesContent` entries.

## Are there any breaking changes?

No. This only changes emitted sourcemap metadata and adds source content to the generated `.js.map` files.

## (Optional) Feedback Focus

Please confirm that inlining source content in sourcemaps is preferred over publishing `src` files or disabling sourcemap emission.
