### PR TITLE
fix(sdk-core): correct sepolia tickLensAddress (was the multicall address)

### DIFF
--- a/.changeset/fix-sepolia-tick-lens-address.md
+++ b/.changeset/fix-sepolia-tick-lens-address.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/sdk-core": patch
+---
+
+Fix the Sepolia `tickLensAddress`, which pointed at the UniswapInterfaceMulticall contract (`0xD7F33bCdb21b359c8ee6F0251d30E94832baAd07`) instead of the TickLens deployment at `0x0b343475d44EC2b4b8243EBF81dc888BF0A14b36`, so any TickLens call on Sepolia reverted.

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -237,7 +237,7 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   quoterAddress: '0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3',
   v3MigratorAddress: '0x729004182cF005CEC8Bd85df140094b6aCbe8b15',
   nonfungiblePositionManagerAddress: '0x1238536071E1c677A632429e3655c799b22cDA52',
-  tickLensAddress: '0xd7f33bcdb21b359c8ee6f0251d30e94832baad07',
+  tickLensAddress: '0x0b343475d44EC2b4b8243EBF81dc888BF0A14b36',
   swapRouter02Address: '0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E',
 
   // TODO: update mixedRouteQuoterV2Address once v4 on sepolia redeployed


### PR DESCRIPTION
## Summary

`SEPOLIA_ADDRESSES.tickLensAddress` is `0xd7f33bcdb21b359c8ee6f0251d30e94832baad07` — the same address as `multicallAddress` on the line above it (just lowercased). A copy-paste error: any consumer resolving TickLens via `CHAIN_TO_ADDRESSES_MAP[ChainId.SEPOLIA].tickLensAddress` / `TICK_LENS_ADDRESSES` calls `getPopulatedTicksInWord` against the UniswapInterfaceMulticall contract and reverts.

This PR points it at the actual Sepolia TickLens deployment: **`0x0b343475d44EC2b4b8243EBF81dc888BF0A14b36`**.

## Verification (on-chain)

- The old value hosts Multicall, not TickLens: `eth_getCode` at `0xD7F33bCdb21b359c8ee6F0251d30E94832baAd07` on Sepolia contains the `multicall((address,uint256,bytes)[])` (`0x1749e1e3`) and `getEthBalance(address)` (`0x4d2301cc`) selectors, and does **not** contain TickLens's `getPopulatedTicksInWord(address,int16)` (`0x351fb478`).
- The new value is the TickLens from the same deploy-v3 run that produced every other Sepolia address in this block. All Sepolia suite contracts were created by deployer `0x3344bbdceb8f6fb52de759c127e4a44efb40432a`; walking its creation nonces:
  - nonce 1 → `0x0227628f…` (v3CoreFactory)
  - nonce 3 → `0xD7F33bCd…` (Multicall)
  - **nonce 5 → `0x0b343475d44EC2b4b8243EBF81dc888BF0A14b36` (TickLens)**
  - nonce 9 → `0x12385360…` (NonfungiblePositionManager)
- Runtime bytecode at the new address is byte-identical in length and prefix to mainnet's TickLens (`0xbfd8137f7d1516D3ea5cA83523914859ec47F573`), and Blockscout has it source-verified under the name `TickLens`: https://eth-sepolia.blockscout.com/address/0x0b343475d44EC2b4b8243EBF81dc888BF0A14b36

## Changes

- `sdks/sdk-core/src/addresses.ts` — one-line address fix
- Changeset: patch bump for `@uniswap/sdk-core`

## Testing

- `bun test src/addresses.test.ts` — 15 pass
- `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)