### PR TITLE
feat(sdk-core): add canonical PermissionedHooks addresses for mainnet and sepolia

### DIFF
--- a/.changeset/add-permissioned-v4-hooks-address.md
+++ b/.changeset/add-permissioned-v4-hooks-address.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/sdk-core": minor
+---
+
+Add canonical PermissionedHooks address (`permissionedV4HooksAddress`) for mainnet and Sepolia, sibling to `permissionedV4PositionManagerAddress`.

--- a/.changeset/add-permissioned-v4-hooks-address.md
+++ b/.changeset/add-permissioned-v4-hooks-address.md
@@ -1,5 +1,0 @@
----
-"@uniswap/sdk-core": minor
----
-
-Add canonical PermissionedHooks address (`permissionedV4HooksAddress`) for mainnet and Sepolia, sibling to `permissionedV4PositionManagerAddress`.

--- a/.changeset/fix-sepolia-tick-lens-address.md
+++ b/.changeset/fix-sepolia-tick-lens-address.md
@@ -1,5 +1,0 @@
----
-"@uniswap/sdk-core": patch
----
-
-Fix the Sepolia `tickLensAddress`, which pointed at the UniswapInterfaceMulticall contract (`0xD7F33bCdb21b359c8ee6F0251d30E94832baAd07`) instead of the TickLens deployment at `0x0b343475d44EC2b4b8243EBF81dc888BF0A14b36`, so any TickLens call on Sepolia reverted.

--- a/sdks/liquidity-launcher-sdk/CHANGELOG.md
+++ b/sdks/liquidity-launcher-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @uniswap/liquidity-launcher-sdk
 
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies [8dc2570]
+- Updated dependencies [0b2b31c]
+  - @uniswap/sdk-core@7.19.0
+  - @uniswap/v3-sdk@3.31.1
+  - @uniswap/v4-sdk@2.3.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/sdks/liquidity-launcher-sdk/package.json
+++ b/sdks/liquidity-launcher-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/liquidity-launcher-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "⚒️ An SDK for launching tokens and auctions with the Uniswap Liquidity Launcher (CCA + LBP) stack",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/router-sdk/CHANGELOG.md
+++ b/sdks/router-sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @uniswap/router-sdk
 
+## 2.11.1
+
+### Patch Changes
+
+- Updated dependencies [8dc2570]
+- Updated dependencies [0b2b31c]
+  - @uniswap/sdk-core@7.19.0
+  - @uniswap/v2-sdk@4.21.1
+  - @uniswap/v3-sdk@3.31.1
+  - @uniswap/v4-sdk@2.3.1
+
 ## 2.11.0
 
 ### Minor Changes

--- a/sdks/router-sdk/package.json
+++ b/sdks/router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/router-sdk",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/sdk-core/CHANGELOG.md
+++ b/sdks/sdk-core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @uniswap/sdk-core
 
+## 7.19.0
+
+### Minor Changes
+
+- 8dc2570: Add canonical PermissionedHooks address (`permissionedV4HooksAddress`) for mainnet and Sepolia, sibling to `permissionedV4PositionManagerAddress`.
+
+### Patch Changes
+
+- 0b2b31c: Fix the Sepolia `tickLensAddress`, which pointed at the UniswapInterfaceMulticall contract (`0xD7F33bCdb21b359c8ee6F0251d30E94832baAd07`) instead of the TickLens deployment at `0x0b343475d44EC2b4b8243EBF81dc888BF0A14b36`, so any TickLens call on Sepolia reverted.
+
 ## 7.18.0
 
 ### Minor Changes

--- a/sdks/sdk-core/package.json
+++ b/sdks/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/sdk-core",
-  "version": "7.18.0",
+  "version": "7.19.0",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -19,6 +19,7 @@ type ChainAddresses = {
   v4StateView?: string
   v4QuoterAddress?: string
   permissionedV4PositionManagerAddress?: string
+  permissionedV4HooksAddress?: string
 }
 
 const DEFAULT_NETWORKS = [ChainId.MAINNET, ChainId.GOERLI, ChainId.SEPOLIA]
@@ -118,6 +119,7 @@ const MAINNET_ADDRESSES: ChainAddresses = {
   v4StateView: '0x7ffe42c4a5deea5b0fec41c94c136cf115597227',
   v4QuoterAddress: '0x52f0e24d1c21c8a0cb1e5a5dd6198556bd9e1203',
   permissionedV4PositionManagerAddress: '0x89628C9B4CE81951a9BC1F36F0688Fad6A6ee248',
+  permissionedV4HooksAddress: '0x69603ab16110Eb0bB5f5E9C8019749eE41A128C0',
 }
 const GOERLI_ADDRESSES: ChainAddresses = {
   ...DEFAULT_ADDRESSES,
@@ -249,6 +251,7 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   v4StateView: '0xe1dd9c3fa50edb962e442f60dfbc432e24537e4c',
   v4QuoterAddress: '0x61b3f2011a92d183c7dbadbda940a7555ccf9227',
   permissionedV4PositionManagerAddress: '0x68fC145BB20b388965bED184Df5ef912215bb3C7',
+  permissionedV4HooksAddress: '0x8B0E8d467af81D9F5B49165e104a2fe1b98328C0',
 }
 
 // Avalanche v3 addresses

--- a/sdks/smart-wallet-sdk/CHANGELOG.md
+++ b/sdks/smart-wallet-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @uniswap/smart-wallet-sdk
 
+## 2.8.1
+
+### Patch Changes
+
+- Updated dependencies [8dc2570]
+- Updated dependencies [0b2b31c]
+  - @uniswap/sdk-core@7.19.0
+
 ## 2.8.0
 
 ### Minor Changes

--- a/sdks/smart-wallet-sdk/package.json
+++ b/sdks/smart-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-wallet-sdk",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "⚒️ An SDK for building applications with smart wallets on Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/uniswapx-sdk/CHANGELOG.md
+++ b/sdks/uniswapx-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @uniswap/uniswapx-sdk
 
+## 3.0.11
+
+### Patch Changes
+
+- Updated dependencies [8dc2570]
+- Updated dependencies [0b2b31c]
+  - @uniswap/sdk-core@7.19.0
+
 ## 3.0.10
 
 ### Patch Changes

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswapx-sdk",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "author": "Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/universal-router-sdk/CHANGELOG.md
+++ b/sdks/universal-router-sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @uniswap/universal-router-sdk
 
+## 5.11.1
+
+### Patch Changes
+
+- Updated dependencies [8dc2570]
+- Updated dependencies [0b2b31c]
+  - @uniswap/sdk-core@7.19.0
+  - @uniswap/router-sdk@2.11.1
+  - @uniswap/v2-sdk@4.21.1
+  - @uniswap/v3-sdk@3.31.1
+  - @uniswap/v4-sdk@2.3.1
+
 ## 5.11.0
 
 ### Minor Changes

--- a/sdks/universal-router-sdk/package.json
+++ b/sdks/universal-router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/universal-router-sdk",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "sdk for integrating with the Universal Router contracts",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/v2-sdk/CHANGELOG.md
+++ b/sdks/v2-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @uniswap/v2-sdk
 
+## 4.21.1
+
+### Patch Changes
+
+- Updated dependencies [8dc2570]
+- Updated dependencies [0b2b31c]
+  - @uniswap/sdk-core@7.19.0
+
 ## 4.21.0
 
 ### Minor Changes

--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v2-sdk",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "description": "🛠 An SDK for building applications on top of Uniswap V2",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/v3-sdk/CHANGELOG.md
+++ b/sdks/v3-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @uniswap/v3-sdk
 
+## 3.31.1
+
+### Patch Changes
+
+- Updated dependencies [8dc2570]
+- Updated dependencies [0b2b31c]
+  - @uniswap/sdk-core@7.19.0
+
 ## 3.31.0
 
 ### Minor Changes

--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v3-sdk",
-  "version": "3.31.0",
+  "version": "3.31.1",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/v4-sdk/CHANGELOG.md
+++ b/sdks/v4-sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @uniswap/v4-sdk
 
+## 2.3.1
+
+### Patch Changes
+
+- Updated dependencies [8dc2570]
+- Updated dependencies [0b2b31c]
+  - @uniswap/sdk-core@7.19.0
+  - @uniswap/v3-sdk@3.31.1
+
 ## 2.3.0
 
 ### Minor Changes

--- a/sdks/v4-sdk/package.json
+++ b/sdks/v4-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v4-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "⚒️ An SDK for building applications on top of Uniswap V4",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [


### PR DESCRIPTION
## Summary

Adds a canonical PermissionedHooks (permissioned v4 pool hook) address per chain to `sdk-core`, as a new optional `permissionedV4HooksAddress` field on `ChainAddresses`, sibling to the existing `permissionedV4PositionManagerAddress`:

- **Mainnet (1)**: `0x69603ab16110Eb0bB5f5E9C8019749eE41A128C0`
- **Sepolia (11155111)**: `0x8B0E8d467af81D9F5B49165e104a2fe1b98328C0`

This field is consumed by the Uniswap web app as the default hook when creating the first-ever permissioned pool for a pair (follow-up to ECO-577), and serves as a programmatic reference for integrators.

Includes a `minor` changeset for `@uniswap/sdk-core`, matching the bump level used when `permissionedV4PositionManagerAddress` was introduced (#590).

## On-chain verification

Both addresses hold deployed code, verified on-chain:

- `poolManager()` on the mainnet hook returns `0x000000000004444c5dc75cB358380D2e3dE08A90`, matching this file's mainnet `v4PoolManagerAddress`.
- `poolManager()` on the Sepolia hook returns `0xE03A1074c86CFeDd5C142C4F04F1a1536e203543`, matching this file's Sepolia `v4PoolManagerAddress`.

## Notes

- A companion Uniswap/universe PR consumes this field: https://github.com/Uniswap/universe/pull/36985 (draft until this publishes and the version bump lands).
- No existing addresses were modified; no other chains were touched.

## Testing

- `bun run build` (sdk-core): clean
- `bun run test` (sdk-core): 375 pass, 0 fail
- `bun run lint` (sdk-core): clean, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Release note

This PR includes the changesets version bump (`bun run version-packages`) so merging it publishes directly — no separate "Version Packages" PR needed. `@uniswap/sdk-core` goes to **7.19.0**. The run also consumed the pending changeset from #654 (Sepolia tickLens fix), so that patch ships in the same release, along with the standard dependency-range patch bumps across the other SDK packages.
