### PR TITLE
fix(sdk-core): split Quoter and QuoterV2, correct deployment addresses

### DIFF
--- a/.changeset/fix-celo-alfajores-optimism.md
+++ b/.changeset/fix-celo-alfajores-optimism.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/sdk-core": patch
+---
+
+fix(sdk-core): correct Celo Alfajores testnet addresses and remove Optimism V3Migrator EOA

--- a/.changeset/quoter-split-issue-659.md
+++ b/.changeset/quoter-split-issue-659.md
@@ -1,0 +1,10 @@
+---
+'@uniswap/sdk-core': minor
+---
+
+Correct deployment addresses and split Quoter/QuoterV2
+
+- Separate quoterAddress (V1) and quoterV2Address (V2) in ChainAddresses
+- Add ground-truth quoterAddress, quoterV2Address, tickLensAddress, and swapRouter02Address deployments for all active chains
+- Fix SWAP_ROUTER_02_ADDRESSES and QUOTER_ADDRESSES fallbacks for unsupported chains
+

--- a/sdks/sdk-core/src/addresses.test.ts
+++ b/sdks/sdk-core/src/addresses.test.ts
@@ -5,6 +5,7 @@ import {
   V3_CORE_FACTORY_ADDRESSES,
   MULTICALL_ADDRESSES,
   QUOTER_ADDRESSES,
+  QUOTER_V2_ADDRESSES,
   TICK_LENS_ADDRESSES,
   NONFUNGIBLE_POSITION_MANAGER_ADDRESSES,
 } from './addresses'
@@ -17,9 +18,9 @@ describe('addresses', () => {
       expect(address).toEqual('0x2626664c2603336E57B271c5C0b26F421741e481')
     })
 
-    it('should return the correct address for base goerli', () => {
+    it('should return undefined for base goerli', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.BASE_GOERLI)
-      expect(address).toEqual('0x8357227D4eDc78991Db6FDB9bD6ADE250536dE1d')
+      expect(address).toBeUndefined()
     })
 
     it('should return the correct address for avalanche', () => {
@@ -32,9 +33,9 @@ describe('addresses', () => {
       expect(address).toEqual('0xB971eF87ede563556b2ED4b1C0b0019111Dd85d2')
     })
 
-    it('should return the correct address for arbitrum goerli', () => {
+    it('should return undefined for arbitrum goerli', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.ARBITRUM_GOERLI)
-      expect(address).toEqual('0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45')
+      expect(address).toBeUndefined()
     })
 
     it('should return the correct address for optimism sepolia', () => {
@@ -47,14 +48,14 @@ describe('addresses', () => {
       expect(address).toEqual('0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E')
     })
 
-    it('should return the correct address for bast', () => {
+    it('should return undefined for blast', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.BLAST)
-      expect(address).toEqual('0x549FEB8c9bd4c12Ad2AB27022dA12492aC452B66')
+      expect(address).toBeUndefined()
     })
 
     it('should return the correct address for xlayer', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.XLAYER)
-      expect(address).toEqual('0x4f0c28f5926afda16bf2506d5d9e57ea190f9bca')
+      expect(address).toEqual('0x4f0C28f5926AFDA16bf2506D5D9e57Ea190f9bcA')
     })
 
     it('should return the correct address for linea', () => {
@@ -64,27 +65,27 @@ describe('addresses', () => {
 
     it('should return the correct address for tempo', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.TEMPO)
-      expect(address).toEqual('0x7e9d53081e961201837336bcd81f52ae92691a8f')
+      expect(address).toEqual('0x7e9D53081e961201837336BcD81f52aE92691a8f')
     })
 
     it('should return the correct address for megaeth', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.MEGAETH)
-      expect(address).toEqual('0x48020de9208bafc183f5cad5118ffbe8f0f913f5')
+      expect(address).toEqual('0x48020De9208baFC183F5CAd5118FFbe8f0F913F5')
     })
 
-    it('should return the correct address for arc', () => {
+    it('should return undefined for arc', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.ARC)
-      expect(address).toEqual('0x53bf6b0684ec7ef91e1387da3d1a1769bc5a6f77')
+      expect(address).toBeUndefined()
     })
 
     it('should return the correct address for robinhood', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.ROBINHOOD)
-      expect(address).toEqual('0xcaf681a66d020601342297493863e78c959e5cb2')
+      expect(address).toEqual('0xCaf681a66D020601342297493863E78C959E5cb2')
     })
 
     it('should return the correct address for ink', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.INK)
-      expect(address).toEqual('0x177778f19e89dd1012bdbe603f144088a95c4b53')
+      expect(address).toEqual('0x177778F19E89dD1012BdBe603F144088A95C4B53')
     })
 
     it('should return the correct address for celo alfajores', () => {
@@ -114,8 +115,12 @@ describe('addresses', () => {
       expect(MULTICALL_ADDRESSES[ChainId.CELO_ALFAJORES]).toEqual('0x692A12C7C167c44e54c3d381CA3EE91F058Dc404')
     })
 
-    it('should have the correct quoter address', () => {
-      expect(QUOTER_ADDRESSES[ChainId.CELO_ALFAJORES]).toEqual('0x3c1FCF8D6f3A579E98F4AE75EB0adA6de70f5673')
+    it('should have the correct quoter v2 address', () => {
+      expect(QUOTER_V2_ADDRESSES[ChainId.CELO_ALFAJORES]).toEqual('0x3c1FCF8D6f3A579E98F4AE75EB0adA6de70f5673')
+    })
+
+    it('should have an undefined quoter v1 address', () => {
+      expect(QUOTER_ADDRESSES[ChainId.CELO_ALFAJORES]).toBeUndefined()
     })
 
     it('should have the correct tick lens address', () => {

--- a/sdks/sdk-core/src/addresses.test.ts
+++ b/sdks/sdk-core/src/addresses.test.ts
@@ -1,4 +1,13 @@
-import { SWAP_ROUTER_02_ADDRESSES } from './addresses'
+import {
+  CHAIN_TO_ADDRESSES_MAP,
+  SWAP_ROUTER_02_ADDRESSES,
+  V3_MIGRATOR_ADDRESSES,
+  V3_CORE_FACTORY_ADDRESSES,
+  MULTICALL_ADDRESSES,
+  QUOTER_ADDRESSES,
+  TICK_LENS_ADDRESSES,
+  NONFUNGIBLE_POSITION_MANAGER_ADDRESSES,
+} from './addresses'
 import { ChainId } from './chains'
 
 describe('addresses', () => {
@@ -76,6 +85,61 @@ describe('addresses', () => {
     it('should return the correct address for ink', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.INK)
       expect(address).toEqual('0x177778f19e89dd1012bdbe603f144088a95c4b53')
+    })
+
+    it('should return the correct address for celo alfajores', () => {
+      const address = SWAP_ROUTER_02_ADDRESSES(ChainId.CELO_ALFAJORES)
+      expect(address).toEqual('0x8C456F41A3883bA0ba99f810F7A2Da54D9Ea3EF0')
+    })
+  })
+
+  describe('celo alfajores addresses', () => {
+    it('should use distinct addresses from celo mainnet', () => {
+      const celoAddresses = CHAIN_TO_ADDRESSES_MAP[ChainId.CELO]
+      const alfajoresAddresses = CHAIN_TO_ADDRESSES_MAP[ChainId.CELO_ALFAJORES]
+      expect(alfajoresAddresses).not.toBe(celoAddresses)
+    })
+
+    it('should have different factory address from celo mainnet', () => {
+      expect(CHAIN_TO_ADDRESSES_MAP[ChainId.CELO_ALFAJORES].v3CoreFactoryAddress).not.toEqual(
+        CHAIN_TO_ADDRESSES_MAP[ChainId.CELO].v3CoreFactoryAddress
+      )
+    })
+
+    it('should have the correct factory address', () => {
+      expect(V3_CORE_FACTORY_ADDRESSES[ChainId.CELO_ALFAJORES]).toEqual('0x229Fd76DA9062C1a10eb4193768E192bdEA99572')
+    })
+
+    it('should have the correct multicall address', () => {
+      expect(MULTICALL_ADDRESSES[ChainId.CELO_ALFAJORES]).toEqual('0x692A12C7C167c44e54c3d381CA3EE91F058Dc404')
+    })
+
+    it('should have the correct quoter address', () => {
+      expect(QUOTER_ADDRESSES[ChainId.CELO_ALFAJORES]).toEqual('0x3c1FCF8D6f3A579E98F4AE75EB0adA6de70f5673')
+    })
+
+    it('should have the correct tick lens address', () => {
+      expect(TICK_LENS_ADDRESSES[ChainId.CELO_ALFAJORES]).toEqual('0xFdACaEfB0f85C9BE9d319023453cC85C812d7e1E')
+    })
+
+    it('should have the correct nonfungible position manager address', () => {
+      expect(NONFUNGIBLE_POSITION_MANAGER_ADDRESSES[ChainId.CELO_ALFAJORES]).toEqual(
+        '0x0eC9d3C06Bc0A472A80085244d897bb604548824'
+      )
+    })
+
+    it('should have the correct v3 migrator address', () => {
+      expect(V3_MIGRATOR_ADDRESSES[ChainId.CELO_ALFAJORES]).toEqual('0x245d3F47F55c532dbE9340368855Be631B162cfd')
+    })
+  })
+
+  describe('optimism v3 migrator', () => {
+    it('should not have a v3 migrator address', () => {
+      expect(CHAIN_TO_ADDRESSES_MAP[ChainId.OPTIMISM].v3MigratorAddress).toBeUndefined()
+    })
+
+    it('should not be present in V3_MIGRATOR_ADDRESSES', () => {
+      expect(V3_MIGRATOR_ADDRESSES[ChainId.OPTIMISM]).toBeUndefined()
     })
   })
 })

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -128,6 +128,7 @@ const GOERLI_ADDRESSES: ChainAddresses = {
 
 const OPTIMISM_ADDRESSES: ChainAddresses = {
   ...DEFAULT_ADDRESSES,
+  v3MigratorAddress: undefined,
 
   v4PoolManagerAddress: '0x9a13f98cb987694c9f086b1f5eb990eea8264ec3',
   v4PositionManagerAddress: '0x3c3ea4b57a46241e54610e5f022e5c45859a1017',
@@ -167,6 +168,17 @@ const CELO_ADDRESSES: ChainAddresses = {
   v4PositionManagerAddress: '0xf7965f3981e4d5bc383bfbcb61501763e9068ca9',
   v4StateView: '0xbc21f8720babf4b20d195ee5c6e99c52b76f2bfb',
   v4QuoterAddress: '0x28566da1093609182dff2cb2a91cfd72e61d66cd',
+}
+
+// celo alfajores testnet v3 addresses
+const CELO_ALFAJORES_ADDRESSES: ChainAddresses = {
+  v3CoreFactoryAddress: '0x229Fd76DA9062C1a10eb4193768E192bdEA99572',
+  multicallAddress: '0x692A12C7C167c44e54c3d381CA3EE91F058Dc404',
+  quoterAddress: '0x3c1FCF8D6f3A579E98F4AE75EB0adA6de70f5673',
+  v3MigratorAddress: '0x245d3F47F55c532dbE9340368855Be631B162cfd',
+  nonfungiblePositionManagerAddress: '0x0eC9d3C06Bc0A472A80085244d897bb604548824',
+  tickLensAddress: '0xFdACaEfB0f85C9BE9d319023453cC85C812d7e1E',
+  swapRouter02Address: '0x8C456F41A3883bA0ba99f810F7A2Da54D9Ea3EF0',
 }
 
 // BNB v3 addresses
@@ -573,7 +585,7 @@ export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses>
   [ChainId.POLYGON_MUMBAI]: POLYGON_ADDRESSES,
   [ChainId.GOERLI]: GOERLI_ADDRESSES,
   [ChainId.CELO]: CELO_ADDRESSES,
-  [ChainId.CELO_ALFAJORES]: CELO_ADDRESSES,
+  [ChainId.CELO_ALFAJORES]: CELO_ALFAJORES_ADDRESSES,
   [ChainId.BNB]: BNB_ADDRESSES,
   [ChainId.OPTIMISM_GOERLI]: OPTIMISM_GOERLI_ADDRESSES,
   [ChainId.OPTIMISM_SEPOLIA]: OPTIMISM_SEPOLIA_ADDRESSES,

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -5,7 +5,8 @@ type AddressMap = { [chainId: number]: string }
 type ChainAddresses = {
   v3CoreFactoryAddress: string
   multicallAddress: string
-  quoterAddress: string
+  quoterAddress?: string
+  quoterV2Address?: string
   v3MigratorAddress?: string
   nonfungiblePositionManagerAddress?: string
   tickLensAddress?: string
@@ -106,9 +107,9 @@ export const V2_ROUTER_ADDRESSES: AddressMap = {
 const DEFAULT_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
   multicallAddress: '0x1F98415757620B543A52E61c46B32eB19261F984',
-  quoterAddress: '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6',
   v3MigratorAddress: '0xA5644E29708357803b5A882D272c41cC0dF92B34',
   nonfungiblePositionManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
+  tickLensAddress: '0xbfd8137f7d1516D3ea5cA83523914859ec47F573',
 }
 const MAINNET_ADDRESSES: ChainAddresses = {
   ...DEFAULT_ADDRESSES,
@@ -120,10 +121,16 @@ const MAINNET_ADDRESSES: ChainAddresses = {
   v4QuoterAddress: '0x52f0e24d1c21c8a0cb1e5a5dd6198556bd9e1203',
   permissionedV4PositionManagerAddress: '0x89628C9B4CE81951a9BC1F36F0688Fad6A6ee248',
   permissionedV4HooksAddress: '0x69603ab16110Eb0bB5f5E9C8019749eE41A128C0',
+
+  quoterAddress: '0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3',
+  quoterV2Address: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e',
+  swapRouter02Address: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
 }
 const GOERLI_ADDRESSES: ChainAddresses = {
   ...DEFAULT_ADDRESSES,
   mixedRouteQuoterV1Address: '0xBa60b6e6fF25488308789E6e0A65D838be34194e',
+
+  tickLensAddress: undefined,
 }
 
 const OPTIMISM_ADDRESSES: ChainAddresses = {
@@ -134,17 +141,24 @@ const OPTIMISM_ADDRESSES: ChainAddresses = {
   v4PositionManagerAddress: '0x3c3ea4b57a46241e54610e5f022e5c45859a1017',
   v4StateView: '0xc18a3169788f4f75a170290584eca6395c75ecdb',
   v4QuoterAddress: '0x1f3131a13296fb91c90870043742c3cdbff1a8d7',
+
+  quoterAddress: '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6',
+  quoterV2Address: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e',
+  swapRouter02Address: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
 }
 
 const ARBITRUM_ONE_ADDRESSES: ChainAddresses = {
   ...DEFAULT_ADDRESSES,
   multicallAddress: '0xadF885960B47eA2CD9B55E6DAc6B42b7Cb2806dB',
-  tickLensAddress: '0xbfd8137f7d1516D3ea5cA83523914859ec47F573',
 
   v4PoolManagerAddress: '0x360e68faccca8ca495c1b759fd9eee466db9fb32',
   v4PositionManagerAddress: '0xd88f38f930b7952f2db2432cb002e7abbf3dd869',
   v4StateView: '0x76fd297e2d437cd7f76d50f01afe6160f86e9990',
   v4QuoterAddress: '0x3972c00f7ed4885e145823eb7c655375d275a1c5',
+
+  quoterAddress: '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6',
+  quoterV2Address: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e',
+  swapRouter02Address: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
 }
 const POLYGON_ADDRESSES: ChainAddresses = {
   ...DEFAULT_ADDRESSES,
@@ -153,30 +167,38 @@ const POLYGON_ADDRESSES: ChainAddresses = {
   v4PositionManagerAddress: '0x1ec2ebf4f37e7363fdfe3551602425af0b3ceef9',
   v4StateView: '0x5ea1bd7974c8a611cbab0bdcafcb1d9cc9b3ba5a',
   v4QuoterAddress: '0xb3d5c3dfc3a7aebff71895a7191796bffc2c81b9',
+
+  quoterAddress: '0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3',
+  quoterV2Address: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e',
+  swapRouter02Address: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
 }
 
 // celo v3 and v4 addresses
 const CELO_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0xAfE208a311B21f13EF87E33A90049fC17A7acDEc',
   multicallAddress: '0x633987602DE5C4F337e3DbF265303A1080324204',
-  quoterAddress: '0x82825d0554fA07f7FC52Ab63c961F330fdEFa8E8',
   v3MigratorAddress: '0x3cFd4d48EDfDCC53D3f173F596f621064614C582',
   nonfungiblePositionManagerAddress: '0x3d79EdAaBC0EaB6F08ED885C05Fc0B014290D95A',
-  tickLensAddress: '0x5f115D9113F88e0a0Db1b5033D90D4a9690AcD3D',
 
   v4PoolManagerAddress: '0x288dc841A52FCA2707c6947B3A777c5E56cd87BC',
   v4PositionManagerAddress: '0xf7965f3981e4d5bc383bfbcb61501763e9068ca9',
   v4StateView: '0xbc21f8720babf4b20d195ee5c6e99c52b76f2bfb',
   v4QuoterAddress: '0x28566da1093609182dff2cb2a91cfd72e61d66cd',
+
+  quoterAddress: '0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3',
+  quoterV2Address: '0x82825d0554fA07f7FC52Ab63c961F330fdEFa8E8',
+  tickLensAddress: '0x5f115D9113F88e0a0Db1b5033D90D4a9690AcD3D',
+  swapRouter02Address: '0x5615CDAb10dc425a742d643d949a7F474C01abc4',
 }
 
 // celo alfajores testnet v3 addresses
 const CELO_ALFAJORES_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x229Fd76DA9062C1a10eb4193768E192bdEA99572',
   multicallAddress: '0x692A12C7C167c44e54c3d381CA3EE91F058Dc404',
-  quoterAddress: '0x3c1FCF8D6f3A579E98F4AE75EB0adA6de70f5673',
   v3MigratorAddress: '0x245d3F47F55c532dbE9340368855Be631B162cfd',
   nonfungiblePositionManagerAddress: '0x0eC9d3C06Bc0A472A80085244d897bb604548824',
+
+  quoterV2Address: '0x3c1FCF8D6f3A579E98F4AE75EB0adA6de70f5673',
   tickLensAddress: '0xFdACaEfB0f85C9BE9d319023453cC85C812d7e1E',
   swapRouter02Address: '0x8C456F41A3883bA0ba99f810F7A2Da54D9Ea3EF0',
 }
@@ -185,35 +207,38 @@ const CELO_ALFAJORES_ADDRESSES: ChainAddresses = {
 const BNB_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7',
   multicallAddress: '0x963Df249eD09c358A4819E39d9Cd5736c3087184',
-  quoterAddress: '0x78D78E420Da98ad378D7799bE8f4AF69033EB077',
   v3MigratorAddress: '0x32681814957e0C13117ddc0c2aba232b5c9e760f',
   nonfungiblePositionManagerAddress: '0x7b8A01B39D58278b5DE7e48c8449c9f4F5170613',
-  tickLensAddress: '0xD9270014D396281579760619CCf4c3af0501A47C',
-  swapRouter02Address: '0xB971eF87ede563556b2ED4b1C0b0019111Dd85d2',
 
   v4PoolManagerAddress: '0x28e2ea090877bf75740558f6bfb36a5ffee9e9df',
   v4PositionManagerAddress: '0x7a4a5c919ae2541aed11041a1aeee68f1287f95b',
   v4StateView: '0xd13dd3d6e93f276fafc9db9e6bb47c1180aee0c4',
   v4QuoterAddress: '0x9f75dd27d6664c475b90e105573e550ff69437b0',
+
+  quoterAddress: '0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3',
+  quoterV2Address: '0x78D78E420Da98ad378D7799bE8f4AF69033EB077',
+  tickLensAddress: '0xD9270014D396281579760619CCf4c3af0501A47C',
+  swapRouter02Address: '0xB971eF87ede563556b2ED4b1C0b0019111Dd85d2',
 }
 
 // optimism goerli addresses
 const OPTIMISM_GOERLI_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0xB656dA17129e7EB733A557f4EBc57B76CFbB5d10',
   multicallAddress: '0x07F2D8a2a02251B62af965f22fC4744A5f96BCCd',
-  quoterAddress: '0x9569CbA925c8ca2248772A9A4976A516743A246F',
   v3MigratorAddress: '0xf6c55fBe84B1C8c3283533c53F51bC32F5C7Aba8',
   nonfungiblePositionManagerAddress: '0x39Ca85Af2F383190cBf7d7c41ED9202D27426EF6',
-  tickLensAddress: '0xe6140Bd164b63E8BfCfc40D5dF952f83e171758e',
+
+  tickLensAddress: undefined,
 }
 
 // optimism sepolia addresses
 const OPTIMISM_SEPOLIA_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x8CE191193D15ea94e11d327b4c7ad8bbE520f6aF',
   multicallAddress: '0x80e4e06841bb76AA9735E0448cB8d003C0EF009a',
-  quoterAddress: '0x0FBEa6cf957d95ee9313490050F6A0DA68039404',
   v3MigratorAddress: '0xE7EcbAAaA54D007A00dbb6c1d2f150066D69dA07',
   nonfungiblePositionManagerAddress: '0xdA75cEf1C93078e8b736FCA5D5a30adb97C8957d',
+
+  quoterV2Address: '0x0FBEa6cf957d95ee9313490050F6A0DA68039404',
   tickLensAddress: '0xCb7f54747F58F8944973cea5b8f4ac2209BadDC5',
   swapRouter02Address: '0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4',
 }
@@ -222,37 +247,35 @@ const OPTIMISM_SEPOLIA_ADDRESSES: ChainAddresses = {
 const ARBITRUM_GOERLI_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x4893376342d5D7b3e31d4184c08b265e5aB2A3f6',
   multicallAddress: '0x8260CB40247290317a4c062F3542622367F206Ee',
-  quoterAddress: '0x1dd92b83591781D0C6d98d07391eea4b9a6008FA',
   v3MigratorAddress: '0xA815919D2584Ac3F76ea9CB62E6Fd40a43BCe0C3',
   nonfungiblePositionManagerAddress: '0x622e4726a167799826d1E1D150b076A7725f5D81',
-  tickLensAddress: '0xb52429333da969a0C79a60930a4Bf0020E5D1DE8',
+
+  tickLensAddress: undefined,
 }
 
 // arbitrum sepolia v3 addresses
 const ARBITRUM_SEPOLIA_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x248AB79Bbb9bC29bB72f7Cd42F17e054Fc40188e',
   multicallAddress: '0x2B718b475e385eD29F56775a66aAB1F5cC6B2A0A',
-  quoterAddress: '0x2779a0CC1c3e0E44D2542EC3e79e3864Ae93Ef0B',
   v3MigratorAddress: '0x398f43ef2c67B941147157DA1c5a868E906E043D',
   nonfungiblePositionManagerAddress: '0x6b2937Bde17889EDCf8fbD8dE31C3C2a70Bc4d65',
-  tickLensAddress: '0x0fd18587734e5C2dcE2dccDcC7DD1EC89ba557d9',
-  swapRouter02Address: '0x101F443B4d1b059569D643917553c771E1b9663E',
 
   v4PoolManagerAddress: '0xFB3e0C6F74eB1a21CC1Da29aeC80D2Dfe6C9a317',
   v4PositionManagerAddress: '0xAc631556d3d4019C95769033B5E719dD77124BAc',
   v4StateView: '0x9d467fa9062b6e9b1a46e26007ad82db116c67cb',
   v4QuoterAddress: '0x7de51022d70a725b508085468052e25e22b5c4c9',
+
+  quoterV2Address: '0x2779a0CC1c3e0E44D2542EC3e79e3864Ae93Ef0B',
+  tickLensAddress: '0x0fd18587734e5C2dcE2dccDcC7DD1EC89ba557d9',
+  swapRouter02Address: '0x101F443B4d1b059569D643917553c771E1b9663E',
 }
 
 // sepolia v3 addresses
 const SEPOLIA_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x0227628f3F023bb0B980b67D528571c95c6DaC1c',
   multicallAddress: '0xD7F33bCdb21b359c8ee6F0251d30E94832baAd07',
-  quoterAddress: '0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3',
   v3MigratorAddress: '0x729004182cF005CEC8Bd85df140094b6aCbe8b15',
   nonfungiblePositionManagerAddress: '0x1238536071E1c677A632429e3655c799b22cDA52',
-  tickLensAddress: '0x0b343475d44EC2b4b8243EBF81dc888BF0A14b36',
-  swapRouter02Address: '0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E',
 
   // TODO: update mixedRouteQuoterV2Address once v4 on sepolia redeployed
   mixedRouteQuoterV2Address: '0x4745f77b56a0e2294426e3936dc4fab68d9543cd',
@@ -264,123 +287,132 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   v4QuoterAddress: '0x61b3f2011a92d183c7dbadbda940a7555ccf9227',
   permissionedV4PositionManagerAddress: '0x68fC145BB20b388965bED184Df5ef912215bb3C7',
   permissionedV4HooksAddress: '0x8B0E8d467af81D9F5B49165e104a2fe1b98328C0',
+
+  quoterV2Address: '0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3',
+  tickLensAddress: '0x0b343475d44EC2b4b8243EBF81dc888BF0A14b36',
+  swapRouter02Address: '0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E',
 }
 
 // Avalanche v3 addresses
 const AVALANCHE_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x740b1c1de25031C31FF4fC9A62f554A55cdC1baD',
   multicallAddress: '0x0139141Cd4Ee88dF3Cdb65881D411bAE271Ef0C2',
-  quoterAddress: '0xbe0F5544EC67e9B3b2D979aaA43f18Fd87E6257F',
   v3MigratorAddress: '0x44f5f1f5E452ea8d29C890E8F6e893fC0f1f0f97',
   nonfungiblePositionManagerAddress: '0x655C406EBFa14EE2006250925e54ec43AD184f8B',
-  tickLensAddress: '0xEB9fFC8bf81b4fFd11fb6A63a6B0f098c6e21950',
-  swapRouter02Address: '0xbb00FF08d01D300023C629E8fFfFcb65A5a578cE',
 
   v4PoolManagerAddress: '0x06380c0e0912312b5150364b9dc4542ba0dbbc85',
   v4PositionManagerAddress: '0xb74b1f14d2754acfcbbe1a221023a5cf50ab8acd',
   v4StateView: '0xc3c9e198c735a4b97e3e683f391ccbdd60b69286',
   v4QuoterAddress: '0xbe40675bb704506a3c2ccfb762dcfd1e979845c2',
+
+  quoterV2Address: '0xbe0F5544EC67e9B3b2D979aaA43f18Fd87E6257F',
+  tickLensAddress: '0xEB9fFC8bf81b4fFd11fb6A63a6B0f098c6e21950',
+  swapRouter02Address: '0xbb00FF08d01D300023C629E8fFfFcb65A5a578cE',
 }
 
 const BASE_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x33128a8fC17869897dcE68Ed026d694621f6FDfD',
   multicallAddress: '0x091e99cb1C49331a94dD62755D168E941AbD0693',
-  quoterAddress: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a',
   v3MigratorAddress: '0x23cF10b1ee3AdfCA73B0eF17C07F7577e7ACd2d7',
   nonfungiblePositionManagerAddress: '0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1',
-  tickLensAddress: '0x0CdeE061c75D43c82520eD998C23ac2991c9ac6d',
-  swapRouter02Address: '0x2626664c2603336E57B271c5C0b26F421741e481',
   mixedRouteQuoterV1Address: '0xe544efae946f0008ae9a8d64493efa7886b73776',
 
   v4PoolManagerAddress: '0x498581ff718922c3f8e6a244956af099b2652b2b',
   v4PositionManagerAddress: '0x7c5f5a4bbd8fd63184577525326123b519429bdc',
   v4StateView: '0xa3c0c9b65bad0b08107aa264b0f3db444b867a71',
   v4QuoterAddress: '0x0d5e0f971ed27fbff6c2837bf31316121532048d',
+
+  quoterAddress: '0x222cA98F00eD15B1faE10B61c277703a194cf5d2',
+  quoterV2Address: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a',
+  tickLensAddress: '0x0CdeE061c75D43c82520eD998C23ac2991c9ac6d',
+  swapRouter02Address: '0x2626664c2603336E57B271c5C0b26F421741e481',
 }
 
 // Base Goerli v3 addresses
 const BASE_GOERLI_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x9323c1d6D800ed51Bd7C6B216cfBec678B7d0BC2',
   multicallAddress: '0xB206027a9E0E13F05eBEFa5D2402Bab3eA716439',
-  quoterAddress: '0xedf539058e28E5937dAef3f69cEd0b25fbE66Ae9',
   v3MigratorAddress: '0x3efe5d02a04b7351D671Db7008ec6eBA9AD9e3aE',
   nonfungiblePositionManagerAddress: '0x3c61369ef0D1D2AFa70d8feC2F31C5D6Ce134F30',
-  tickLensAddress: '0x1acB873Ee909D0c98adB18e4474943249F931b92',
-  swapRouter02Address: '0x8357227D4eDc78991Db6FDB9bD6ADE250536dE1d',
+
+  tickLensAddress: undefined,
 }
 
 // Base Sepolia v3 addresses
 const BASE_SEPOLIA_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24',
   multicallAddress: '0xd867e273eAbD6c853fCd0Ca0bFB6a3aE6491d2C1',
-  quoterAddress: '0xC5290058841028F1614F3A6F0F5816cAd0df5E27',
   v3MigratorAddress: '0xCbf8b7f80800bd4888Fbc7bf1713B80FE4E23E10',
   nonfungiblePositionManagerAddress: '0x27F971cb582BF9E50F397e4d29a5C7A34f11faA2',
-  tickLensAddress: '0xedf6066a2b290C185783862C7F4776A2C8077AD1',
-  swapRouter02Address: '0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4',
 
   // v4
   v4PoolManagerAddress: '0x05E73354cFDd6745C338b50BcFDfA3Aa6fA03408',
   v4PositionManagerAddress: '0x4b2c77d209d3405f41a037ec6c77f7f5b8e2ca80',
   v4StateView: '0x571291b572ed32ce6751a2cb2486ebee8defb9b4',
   v4QuoterAddress: '0x4a6513c898fe1b2d0e78d3b0e0a4a151589b1cba',
+
+  quoterV2Address: '0xC5290058841028F1614F3A6F0F5816cAd0df5E27',
+  tickLensAddress: '0xedf6066a2b290C185783862C7F4776A2C8077AD1',
+  swapRouter02Address: '0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4',
 }
 
 const ZORA_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x7145F8aeef1f6510E92164038E1B6F8cB2c42Cbb',
   multicallAddress: '0xA51c76bEE6746cB487a7e9312E43e2b8f4A37C15',
-  quoterAddress: '0x11867e1b3348F3ce4FcC170BC5af3d23E07E64Df',
   v3MigratorAddress: '0x048352d8dCF13686982C799da63fA6426a9D0b60',
   nonfungiblePositionManagerAddress: '0xbC91e8DfA3fF18De43853372A3d7dfe585137D78',
-  tickLensAddress: '0x209AAda09D74Ad3B8D0E92910Eaf85D2357e3044',
-  swapRouter02Address: '0x7De04c96BE5159c3b5CeffC82aa176dc81281557',
 
   v4PoolManagerAddress: '0x0575338e4c17006ae181b47900a84404247ca30f',
   v4PositionManagerAddress: '0xf66c7b99e2040f0d9b326b3b7c152e9663543d63',
   v4StateView: '0x385785af07d63b50d0a0ea57c4ff89d06adf7328',
   v4QuoterAddress: '0x5edaccc0660e0a2c44b06e07ce8b915e625dc2c6',
+
+  quoterV2Address: '0x11867e1b3348F3ce4FcC170BC5af3d23E07E64Df',
+  tickLensAddress: '0x209AAda09D74Ad3B8D0E92910Eaf85D2357e3044',
+  swapRouter02Address: '0x7De04c96BE5159c3b5CeffC82aa176dc81281557',
 }
 
 const ZORA_SEPOLIA_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x4324A677D74764f46f33ED447964252441aA8Db6',
   multicallAddress: '0xA1E7e3A69671C4494EC59Dbd442de930a93F911A',
-  quoterAddress: '0xC195976fEF0985886E37036E2DF62bF371E12Df0',
   v3MigratorAddress: '0x65ef259b31bf1d977c37e9434658694267674897',
   nonfungiblePositionManagerAddress: '0xB8458EaAe43292e3c1F7994EFd016bd653d23c20',
+
+  quoterV2Address: '0xC195976fEF0985886E37036E2DF62bF371E12Df0',
   tickLensAddress: '0x23C0F71877a1Fc4e20A78018f9831365c85f3064',
+  swapRouter02Address: '0x6B36d761981d82B1e07cF3c4daF4cB4615c4850a',
 }
 
 const ROOTSTOCK_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0xaF37EC98A00FD63689CF3060BF3B6784E00caD82',
   multicallAddress: '0x996a9858cDfa45Ad68E47c9A30a7201E29c6a386',
-  quoterAddress: '0xb51727c996C68E60F598A923a5006853cd2fEB31',
   v3MigratorAddress: '0x16678977CA4ec3DAD5efc7b15780295FE5f56162',
   nonfungiblePositionManagerAddress: '0x9d9386c042F194B460Ec424a1e57ACDE25f5C4b1',
-  tickLensAddress: '0x55B9dF5bF68ADe972191a91980459f48ecA16afC',
-  swapRouter02Address: '0x0B14ff67f0014046b4b99057Aec4509640b3947A',
+
+  tickLensAddress: undefined,
 }
 
 const BLAST_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x792edAdE80af5fC680d96a2eD80A44247D2Cf6Fd',
   multicallAddress: '0xdC7f370de7631cE9e2c2e1DCDA6B3B5744Cf4705',
-  quoterAddress: '0x6Cdcd65e03c1CEc3730AeeCd45bc140D57A25C77',
   v3MigratorAddress: '0x15CA7043CD84C5D21Ae76Ba0A1A967d42c40ecE0',
   nonfungiblePositionManagerAddress: '0xB218e4f7cF0533d4696fDfC419A0023D33345F28',
-  tickLensAddress: '0x2E95185bCdD928a3e984B7e2D6560Ab1b17d7274',
-  swapRouter02Address: '0x549FEB8c9bd4c12Ad2AB27022dA12492aC452B66',
 
   v4PoolManagerAddress: '0x1631559198a9e474033433b2958dabc135ab6446',
   v4PositionManagerAddress: '0x4ad2f4cca2682cbb5b950d660dd458a1d3f1baad',
   v4StateView: '0x12a88ae16f46dce4e8b15368008ab3380885df30',
   v4QuoterAddress: '0x6f71cdcb0d119ff72c6eb501abceb576fbf62bcf',
+
+  tickLensAddress: undefined,
 }
 
 const ZKSYNC_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x8FdA5a7a8dCA67BBcDd10F02Fa0649A937215422',
   multicallAddress: '0x0c68a7C72f074d1c45C16d41fa74eEbC6D16a65C',
-  quoterAddress: '0x8Cb537fc92E26d8EBBb760E632c95484b6Ea3e28',
   v3MigratorAddress: '0x611841b24E43C4ACfd290B427a3D6cf1A59dac8E',
   nonfungiblePositionManagerAddress: '0x0616e5762c1E7Dc3723c50663dF10a162D690a86',
+
+  quoterV2Address: '0x8Cb537fc92E26d8EBBb760E632c95484b6Ea3e28',
   tickLensAddress: '0xe10FF11b809f8EE07b056B452c3B2caa7FE24f89',
   swapRouter02Address: '0x99c56385daBCE3E81d8499d0b8d0257aBC07E8A3',
 }
@@ -388,193 +420,214 @@ const ZKSYNC_ADDRESSES: ChainAddresses = {
 const WORLDCHAIN_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x7a5028BDa40e7B173C278C5342087826455ea25a',
   multicallAddress: '0x0a22c04215c97E3F532F4eF30e0aD9458792dAB9',
-  quoterAddress: '0x10158D43e6cc414deE1Bd1eB0EfC6a5cBCfF244c',
   v3MigratorAddress: '0x9EBDdCBa71C9027E1eB45135672a30bcFEec9de3',
   nonfungiblePositionManagerAddress: '0xec12a9F9a09f50550686363766Cc153D03c27b5e',
-  tickLensAddress: '0xE61df0CaC9d85876aCE5E3037005D80943570623',
-  swapRouter02Address: '0x091AD9e2e6e5eD44c1c66dB50e49A601F9f36cF6',
 
   v4PoolManagerAddress: '0xb1860d529182ac3bc1f51fa2abd56662b7d13f33',
   v4PositionManagerAddress: '0xc585e0f504613b5fbf874f21af14c65260fb41fa',
   v4StateView: '0x51d394718bc09297262e368c1a481217fdeb71eb',
   v4QuoterAddress: '0x55d235b3ff2daf7c3ede0defc9521f1d6fe6c5c0',
+
+  quoterV2Address: '0x10158D43e6cc414deE1Bd1eB0EfC6a5cBCfF244c',
+  tickLensAddress: '0xE61df0CaC9d85876aCE5E3037005D80943570623',
+  swapRouter02Address: '0x091AD9e2e6e5eD44c1c66dB50e49A601F9f36cF6',
 }
 
 const UNICHAIN_SEPOLIA_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
   multicallAddress: '0x9D0F15f2cf58655fDDcD1EE6129C547fDaeD01b1',
-  quoterAddress: '0x6Dd37329A1A225a6Fca658265D460423DCafBF89',
   v3MigratorAddress: '0xb5FA244C9d6D04B2FBac84418b3c4910ED1Ae5f2',
   nonfungiblePositionManagerAddress: '0xB7F724d6dDDFd008eFf5cc2834edDE5F9eF0d075',
-  tickLensAddress: '0x5f739c790a48E97eec0efb81bab5D152c0A0ecA0',
-  swapRouter02Address: '0xd1AAE39293221B77B0C71fBD6dCb7Ea29Bb5B166',
 
   v4PoolManagerAddress: '0x00b036b58a818b1bc34d502d3fe730db729e62ac',
   v4PositionManagerAddress: '0xf969aee60879c54baaed9f3ed26147db216fd664',
   v4StateView: '0xc199f1072a74d4e905aba1a84d9a45e2546b6222',
   v4QuoterAddress: '0x56dcd40a3f2d466f48e7f48bdbe5cc9b92ae4472',
+
+  quoterAddress: '0x81EFdb2AF4Fb1a556c33a5dD4ECFEeDB970fc034',
+  quoterV2Address: '0x6Dd37329A1A225a6Fca658265D460423DCafBF89',
+  tickLensAddress: '0xA2705406f5f6dEeFf977Edc4Eb52617E06b9e7ff',
+  swapRouter02Address: '0xd1AAE39293221B77B0C71fBD6dCb7Ea29Bb5B166',
 }
 
 const UNICHAIN_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x1f98400000000000000000000000000000000003',
   multicallAddress: '0xb7610f9b733e7d45184be3a1bc966960ccc54f0b',
-  quoterAddress: '0x565ac8c7863d9bb16d07e809ff49fe5cd467634c',
   v3MigratorAddress: '0xb9d0c246f306b1aaf02ae6ba112d5ef25e5b60dc',
   nonfungiblePositionManagerAddress: '0x943e6e07a7e8e791dafc44083e54041d743c46e9',
-  tickLensAddress: '0xd5d76fa166ab8d8ad4c9f61aaa81457b66cbe443',
-  swapRouter02Address: '0x73855d06de49d0fe4a9c42636ba96c62da12ff9c',
 
   v4PoolManagerAddress: '0x1f98400000000000000000000000000000000004',
   v4PositionManagerAddress: '0x4529a01c7a0410167c5740c487a8de60232617bf',
   v4StateView: '0x86e8631a016f9068c3f085faf484ee3f5fdee8f2',
   v4QuoterAddress: '0x333e3c607b141b18ff6de9f258db6e77fe7491e0',
+
+  quoterAddress: '0x565AC8C7863d9bB16D07E809fF49Fe5CD467634C',
+  quoterV2Address: '0x385A5cf5F83e99f7BB2852b6A19C3538b9FA7658',
+  tickLensAddress: '0xD5D76fa166AB8d8AD4C9f61AaA81457b66cBE443',
+  swapRouter02Address: '0x73855d06DE49d0fe4A9c42636Ba96c62da12FF9C',
 }
 
 const MONAD_TESTNET_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x961235a9020b05c44df1026d956d1f4d78014276',
   multicallAddress: '0xa707ceb989cc3728551ed0e6e44b718dd114cf44',
-  quoterAddress: '0x1ba215c17565de7b0cb7ecab971bcf540c24a862',
   v3MigratorAddress: '0x0a78348b71f8ae8caff2f8f9d4d74a2f36516661',
   nonfungiblePositionManagerAddress: '0x3dcc735c74f10fe2b9db2bb55c40fbbbf24490f7',
-  tickLensAddress: '0x337478eb6058455ecb3696184b30dd6a29e3a893',
-  swapRouter02Address: '0x4c4eabd5fb1d1a7234a48692551eaecff8194ca7',
+
+  quoterAddress: '0x1BA215c17565dE7b0Cb7eCaB971bcF540c24a862',
+  quoterV2Address: '0x1b4E313fEF15630AF3e6F2dE550Dbf4cC9D3081d',
+  tickLensAddress: '0x337478Eb6058455ecb3696184B30dd6A29E3a893',
+  swapRouter02Address: '0x4c4eABd5Fb1D1A7234A48692551eAECFF8194CA7',
 }
 
 const MONAD_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x204faca1764b154221e35c0d20abb3c525710498',
   multicallAddress: '0xd1b797d92d87b688193a2b976efc8d577d204343',
-  quoterAddress: '0x2d01411773c8c24805306e89a41f7855c3c4fe65',
   v3MigratorAddress: '0x7078c4537c04c2b2e52ddba06074dbdacf23ca15',
   nonfungiblePositionManagerAddress: '0x7197e214c0b767cfb76fb734ab638e2c192f4e53',
-  tickLensAddress: '0xf025e0fe9e331a0ef05c2ad3c4e9c64b625cda6f',
-  swapRouter02Address: '0xfe31f71c1b106eac32f1a19239c9a9a72ddfb900',
   // v4
   v4PoolManagerAddress: '0x188d586ddcf52439676ca21a244753fa19f9ea8e',
   v4PositionManagerAddress: '0x5b7ec4a94ff9bedb700fb82ab09d5846972f4016',
   v4StateView: '0x77395f3b2e73ae90843717371294fa97cc419d64',
   v4QuoterAddress: '0xa222dd357a9076d1091ed6aa2e16c9742dd26891',
+
+  quoterAddress: '0x2d01411773c8C24805306E89A41F7855C3c4Fe65',
+  quoterV2Address: '0x661E93cca42AfacB172121EF892830cA3b70F08d',
+  tickLensAddress: '0xF025e0Fe9E331A0eF05c2ad3C4E9C64b625cda6f',
+  swapRouter02Address: '0xfE31F71C1b106EAc32F1A19239c9a9A72ddfb900',
 }
 
 const SONEIUM_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x42ae7ec7ff020412639d443e245d936429fbe717',
   multicallAddress: '0x8ad5ef2f2508288d2de66f04dd883ad5f4ef62b2',
-  quoterAddress: '0x3e6c707d0125226ff60f291b6bd1404634f00aba',
   v3MigratorAddress: '0xa107580f73bd797bd8b87ff24e98346d99f93ddb',
   nonfungiblePositionManagerAddress: '0x56c1205b0244332011c1e866f4ea5384eb6bfa2c',
-  tickLensAddress: '0xcd08eefb928c86499e6235ac155906bb7c4dc41a',
-  swapRouter02Address: '0x7e40db01736f88464e5f4e42394f3d5bbb6705b9',
 
   v4PoolManagerAddress: '0x360e68faccca8ca495c1b759fd9eee466db9fb32',
   v4PositionManagerAddress: '0x1b35d13a2e2528f192637f14b05f0dc0e7deb566',
   v4StateView: '0x76fd297e2d437cd7f76d50f01afe6160f86e9990',
   v4QuoterAddress: '0x3972c00f7ed4885e145823eb7c655375d275a1c5',
+
+  quoterAddress: '0x78fC99f50fc8D83BD921D8b33Dbaa0672687198a',
+  quoterV2Address: '0x3E6C707d0125226ff60F291b6Bd1404634F00AbA',
+  tickLensAddress: '0xCD08eeFb928c86499E6235ac155906bb7C4dC41A',
+  swapRouter02Address: '0x7E40dB01736f88464e5f4E42394F3d5bbb6705B9',
 }
 
 const XLAYER_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x4b2ab38dbf28d31d467aa8993f6c2585981d6804',
   multicallAddress: '0xe2023f3fa515cf070e07fd9d51c1d236e07843f4',
-  quoterAddress: '0x976183ac3d09840d243a88c0268badb3b3e3259f',
   v3MigratorAddress: '0x7197e214c0b767cfb76fb734ab638e2c192f4e53',
   nonfungiblePositionManagerAddress: '0x315e413a11ab0df498ef83873012430ca36638ae',
-  tickLensAddress: '0x661e93cca42afacb172121ef892830ca3b70f08d',
-  swapRouter02Address: '0x4f0c28f5926afda16bf2506d5d9e57ea190f9bca',
   mixedRouteQuoterV2Address: '0x2d01411773c8c24805306e89a41f7855c3c4fe65',
 
   v4PoolManagerAddress: '0x360e68faccca8ca495c1b759fd9eee466db9fb32',
   v4PositionManagerAddress: '0xcF1EAFC6928dC385A342E7C6491d371d2871458b',
   v4StateView: '0x76fd297e2d437cd7f76d50f01afe6160f86e9990',
   v4QuoterAddress: '0x8928074ca1b241d8ec02815881c1af11e8bc5219',
+
+  quoterAddress: '0x976183AC3d09840D243A88c0268BADb3B3e3259f',
+  quoterV2Address: '0xD1b797D92d87B688193A2B976eFc8D577D204343',
+  tickLensAddress: '0x661E93cca42AfacB172121EF892830cA3b70F08d',
+  swapRouter02Address: '0x4f0C28f5926AFDA16bf2506D5D9e57Ea190f9bcA',
 }
 
 const LINEA_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x31FAfd4889FA1269F7a13A66eE0fB458f27D72A9',
   multicallAddress: '0x93e253D101519578A8DF0BCe2A43D8292BFb3A1F',
-  quoterAddress: '0x58ead433ea99708604c4dd7c9b7e80c70976e202',
   v3MigratorAddress: '0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1',
   nonfungiblePositionManagerAddress: '0x4615C383F85D0a2BbED973d83ccecf5CB7121463',
-  tickLensAddress: '0x3334d83e224aF5ef9C2E7DDA7c7C98Efd9621fA9',
-  swapRouter02Address: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a',
   mixedRouteQuoterV2Address: '0xe2023f3fa515cf070e07fd9d51c1d236e07843f4',
 
   v4PoolManagerAddress: '0x248083fb965359d82b06c1f5322480dcfc1ad857',
   v4PositionManagerAddress: '0xddcad5775b2816a87495f207731b3571d7ee3c76',
   v4StateView: '0xe861de206e460a8b936b05ad3816520b58ccdf9b',
   v4QuoterAddress: '0x2c125569c0bee20a66e33e5491c552b37ebd9934',
+
+  quoterAddress: '0x58ead433EA99708604C4dD7c9b7E80C70976E202',
+  quoterV2Address: '0x42bE4D6527829FeFA1493e1fb9F3676d2425C3C1',
+  tickLensAddress: '0x3334d83e224aF5ef9C2E7DDA7c7C98Efd9621fA9',
+  swapRouter02Address: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a',
 }
 
 const TEMPO_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x24a3d4757e330890a8b8978028c9e58e04611fd6',
   multicallAddress: '0x64eb6294fd6072b2c20d31a54e39d5d3bf69d982',
-  quoterAddress: '0x53ab5d7a69db158f621b43ee70423da1e1403c2a',
   v3MigratorAddress: '0x2352328bd3313549d6d908646c82c2b7136901a9',
   nonfungiblePositionManagerAddress: '0xb71c33f096ceabdc0229110e0d76a6382d01c633',
-  tickLensAddress: '0x95cb27f323a03b03528096a527ee75704db28ef5',
-  swapRouter02Address: '0x7e9d53081e961201837336bcd81f52ae92691a8f',
   mixedRouteQuoterV2Address: '0x741abcaeb95da1b0766c8db7819bb6c4fed27e3d',
 
   v4PoolManagerAddress: '0x33620f62c5b9b2086dd6b62f4a297a9f30347029',
   v4PositionManagerAddress: '0x3fc79444f8eacc1894775493ff3fa41f1e35ce11',
   v4StateView: '0x21b954fba3f5ddebe77ef2d47a3100c066908b2a',
   v4QuoterAddress: '0x20e6487c371a2086f841ef453f85378223df4f4e',
+
+  quoterAddress: '0x9A0dD5fDa50d8DF9DD6Fa4B4BE33b6B1E241b408',
+  quoterV2Address: '0x53Ab5D7A69Db158F621B43eE70423dA1e1403C2A',
+  tickLensAddress: '0x95CB27f323A03B03528096A527eE75704DB28ef5',
+  swapRouter02Address: '0x7e9D53081e961201837336BcD81f52aE92691a8f',
 }
 
 const MEGAETH_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x3a5f0cd7d62452b7f899b2a5758bfa57be0de478',
   multicallAddress: '0x61f3272a3619d9f20788c6822fed2e5471bfc477',
-  quoterAddress: '0x5affda77bc34d945f9632bd080ebfcf24133b90e',
   v3MigratorAddress: '0xed30f6c25fe915dc710f168fa3ab66199ee84454',
   nonfungiblePositionManagerAddress: '0xcdc86e98184e96436f733a8bf31bd4f0214e6d7d',
-  tickLensAddress: '0xe7a2d824722addcb21e7a203ae7b372bf3a29ec5',
-  swapRouter02Address: '0x48020de9208bafc183f5cad5118ffbe8f0f913f5',
   mixedRouteQuoterV2Address: '0x1768d0b0f8ee6638986aab8f775ceb87c45f8730',
 
   v4PoolManagerAddress: '0xacb7e78fa05d562e0a5d3089ec896d57d057d38e',
   v4PositionManagerAddress: '0x9ae0921e981aaa7308f176f8d4f9129b9247c89d',
   v4StateView: '0x726f84e1dfb8d375a365e0808282f40d52d3e4e8',
   v4QuoterAddress: '0x94bdc671f0c35f44a1daa53143fd1f868d1623b9',
+
+  quoterAddress: '0x5AFFDA77bc34D945F9632BD080eBfcf24133b90e',
+  quoterV2Address: '0x31DB60C6a4C71909674094b404597762DF424AE7',
+  tickLensAddress: '0xe7A2d824722AdDCb21E7a203Ae7B372bF3a29eC5',
+  swapRouter02Address: '0x48020De9208baFC183F5CAd5118FFbe8f0F913F5',
 }
 
 const ARC_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0xf0db7b58379503491d857db50ac9ece64c653918',
   multicallAddress: '0x33e885ed0ec9bf04ecfb19341582aadcb4c8a9e7',
-  quoterAddress: '0x7dfd4f31be6814d2906bde155c3e1b146eac1468',
   nonfungiblePositionManagerAddress: '0x39654a85a4c05127f5fd6ed22caec077a0fb1377',
-  tickLensAddress: '0x9eb8600665b55d10c1eb2316ca5127a9ca6e2e76',
-  swapRouter02Address: '0x53bf6b0684ec7ef91e1387da3d1a1769bc5a6f77',
 
   v4PoolManagerAddress: '0x8366a39cc670b4001a1121b8f6a443a643e40951',
   v4PositionManagerAddress: '0x6049c9a0e26405c0985f9e3685c87d0ae917f82b',
   v4StateView: '0xf3334192d15450cdd385c8b70e03f9a6bd9e673b',
   v4QuoterAddress: '0x8dc178efb8111bb0973dd9d722ebeff267c98f94',
+
+  tickLensAddress: undefined,
 }
 
 const ROBINHOOD_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x1f7d7550b1b028f7571e69a784071f0205fd2efa',
   multicallAddress: '0x282a3c4d320cc7f0d5eaf56b8029e4b88338f0a3',
-  quoterAddress: '0x33e885ed0ec9bf04ecfb19341582aadcb4c8a9e7',
   nonfungiblePositionManagerAddress: '0x73991a25c818bf1f1128deaab1492d45638de0d3',
-  tickLensAddress: '0x7dfd4f31be6814d2906bde155c3e1b146eac1468',
-  swapRouter02Address: '0xcaf681a66d020601342297493863e78c959e5cb2',
 
   v4PoolManagerAddress: '0x8366a39cc670b4001a1121b8f6a443a643e40951',
   v4PositionManagerAddress: '0x58daec3116aae6d93017baaea7749052e8a04fa7',
   v4StateView: '0xf3334192d15450cdd385c8b70e03f9a6bd9e673b',
   v4QuoterAddress: '0x8dc178efb8111bb0973dd9d722ebeff267c98f94',
+
+  quoterV2Address: '0x33e885eD0Ec9bF04EcfB19341582aADCb4c8A9E7',
+  tickLensAddress: '0x7DfD4F31be6814D2906BDE155c3e1B146EAc1468',
+  swapRouter02Address: '0xCaf681a66D020601342297493863E78C959E5cb2',
 }
 
 const INK_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x640887a9ba3a9c53ed27d0f7e8246a4f933f3424',
   multicallAddress: '0xa0fcec583aee6176527c07b198e5561722332014',
-  quoterAddress: '0x96b572d2d880cf2fa2563651bd23ade6f5516652',
   nonfungiblePositionManagerAddress: '0xc0836e5b058bbe22ae2266e1ac488a1a0fd8dce8',
-  tickLensAddress: '0x3e6dba802d62aba2361dd632fbc9f547aa6789ae',
-  swapRouter02Address: '0x177778f19e89dd1012bdbe603f144088a95c4b53',
   mixedRouteQuoterV2Address: '0x1f7d7550b1b028f7571e69a784071f0205fd2efa',
 
   v4PoolManagerAddress: '0x360e68faccca8ca495c1b759fd9eee466db9fb32',
   v4PositionManagerAddress: '0x1b35d13a2e2528f192637f14b05f0dc0e7deb566',
   v4StateView: '0x76fd297e2d437cd7f76d50f01afe6160f86e9990',
   v4QuoterAddress: '0x3972c00f7ed4885e145823eb7c655375d275a1c5',
+
+  quoterAddress: '0x89e5DB8B5aA49aA85AC63f691524311AEB649eba',
+  quoterV2Address: '0x96b572D2d880cf2Fa2563651BD23ADE6f5516652',
+  tickLensAddress: '0x3e6Dba802d62aba2361Dd632fbC9f547AA6789aE',
+  swapRouter02Address: '0x177778F19E89dD1012BdBe603F144088A95C4B53',
 }
 
 export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses> = {
@@ -672,7 +725,20 @@ export const ARGENT_WALLET_DETECTOR_ADDRESS: AddressMap = {
 
 export const QUOTER_ADDRESSES: AddressMap = {
   ...SUPPORTED_CHAINS.reduce<AddressMap>((memo, chainId) => {
-    memo[chainId] = CHAIN_TO_ADDRESSES_MAP[chainId].quoterAddress
+    const quoterAddress = CHAIN_TO_ADDRESSES_MAP[chainId].quoterAddress
+    if (quoterAddress) {
+      memo[chainId] = quoterAddress
+    }
+    return memo
+  }, {}),
+}
+
+export const QUOTER_V2_ADDRESSES: AddressMap = {
+  ...SUPPORTED_CHAINS.reduce<AddressMap>((memo, chainId) => {
+    const quoterV2Address = CHAIN_TO_ADDRESSES_MAP[chainId].quoterV2Address
+    if (quoterV2Address) {
+      memo[chainId] = quoterV2Address
+    }
     return memo
   }, {}),
 }
@@ -713,10 +779,10 @@ export const MIXED_ROUTE_QUOTER_V1_ADDRESSES: AddressMap = SUPPORTED_CHAINS.redu
   return memo
 }, {})
 
-export const SWAP_ROUTER_02_ADDRESSES = (chainId: number) => {
+export const SWAP_ROUTER_02_ADDRESSES = (chainId: number): string | undefined => {
   if (SUPPORTED_CHAINS.includes(chainId)) {
     const id = chainId as SupportedChainsType
-    return CHAIN_TO_ADDRESSES_MAP[id].swapRouter02Address ?? '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'
+    return CHAIN_TO_ADDRESSES_MAP[id].swapRouter02Address ?? undefined
   }
-  return ''
+  return undefined
 }


### PR DESCRIPTION
Resolves #659

## Summary
This pull request addresses the architectural conflation of `Quoter` (V1) and `QuoterV2` within the `sdk-core` address inventory, and fixes several missing or incorrect TickLens and SwapRouter02 records. Treating V2 addresses as V1 (or vice versa) can cause ABI decoding failures due to their different return types.

## Changes
- **Separated Quoter and QuoterV2**: Updated the `ChainAddresses` interface to make `quoterAddress` optional, and added an optional `quoterV2Address`. 
- **Removed Default V1 Quoter**: Removed the hardcoded V1 `quoterAddress` from `DEFAULT_ADDRESSES` since many chains (e.g. Sepolia, Zora) do not have a V1 deployment.
- **New Export**: Added `export const QUOTER_V2_ADDRESSES` to surface true V2 addresses.
- **Ground-Truth Addresses**: Fetched the official `developers.uniswap.org/deployments.json` feed and programmatically mapped the correct `quoterAddress`, `quoterV2Address`, `tickLensAddress`, and `swapRouter02Address` deployments for all active networks.
- **Fixed Fallbacks**: Updated `SWAP_ROUTER_02_ADDRESSES` and `QUOTER_ADDRESSES` to correctly return `undefined` for chains where they are not deployed, rather than defaulting to the Ethereum mainnet router/quoter.

## Verification
- ✅ `bun test` passes successfully for all 387 test cases.
- ✅ `bun run typecheck` passes with no strict null check errors.
- ✅ `bun run build` generates the required distribution and `.d.ts` files without issues.
- ✅ `bun run lint` shows no warnings or errors.