### PR TITLE
feat(liquidity-launcher-sdk): quick-launch graduation pool tick spacing — the 2026-08-05 redeploy mints at 25

### DIFF
--- a/.changeset/quick-launch-pool-tick-spacing.md
+++ b/.changeset/quick-launch-pool-tick-spacing.md
@@ -1,0 +1,11 @@
+---
+'@uniswap/liquidity-launcher-sdk': minor
+---
+
+Quick-launch preset: state the graduation pool's tick spacing, which the 2026-08-05 chain-4663 full redeploy changed on-chain from 50 to 25 without any SDK constant describing it.
+
+- `QUICK_LAUNCH_POOL_TICK_SPACING` (new) → `25`. The value the launch flow passes in `MigratorParameters.poolParameters` since the redeploy — deliberately NOT the generic `feeToTickSpacing` derivation, which yields 50 for the 2500 fee tier. Evidence: the post-redeploy `Initialize` census on chain 4663 shows every quick-launch graduation pool minted at spacing 25 (295 pools in the redeploy's first day, zero new pools at 50).
+- `QUICK_LAUNCH_ALLOWED_POOL_TICK_SPACINGS` (new) → `[25, 50]`. The append-only grandfather set (same shape as `QUICK_LAUNCH_ALLOWED_GRADUATION_FDV_USD`): pools are permanent, so routing/discovery consumers deriving a token's candidate launch pools must race a `(QUICK_LAUNCH_LP_FEE, spacing)` key for every entry — the token address alone cannot say which generation minted its pool. This is the constant rh-cca's `LAUNCH_POOL_TIERS`-style routing should consume instead of hand-maintained literals (Uniswap/universe#38608 shipped the interim literal).
+- `QUICK_LAUNCH_PRESET.lp.tickSpacing` (new field) → `QUICK_LAUNCH_POOL_TICK_SPACING`, beside the existing `lp.fee`.
+
+`feeToTickSpacing` itself is unchanged — it remains the generic v3-canonical/interface derivation used for validation; the preset now states the observed on-chain value where the launch flow no longer follows that formula. `isQuickLaunch` classification is unaffected (it never matched on the pool key).

--- a/sdks/liquidity-launcher-sdk/src/quickLaunch.test.ts
+++ b/sdks/liquidity-launcher-sdk/src/quickLaunch.test.ts
@@ -9,11 +9,13 @@ import {
   PERMANENT_TIMELOCK_REQUEST_SECONDS,
   PERMANENT_UNLOCK_BLOCK_THRESHOLD,
   QUICK_LAUNCH_ALLOWED_GRADUATION_FDV_USD,
+  QUICK_LAUNCH_ALLOWED_POOL_TICK_SPACINGS,
   QUICK_LAUNCH_DURATION_SECONDS,
   QUICK_LAUNCH_FLOOR_FDV_USD,
   QUICK_LAUNCH_GRADUATION_FDV_TOLERANCE_RATIO,
   QUICK_LAUNCH_GRADUATION_FDV_USD,
   QUICK_LAUNCH_GRADUATION_RAISE_USD,
+  QUICK_LAUNCH_POOL_TICK_SPACING,
   QUICK_LAUNCH_PRESET,
   QUICK_LAUNCH_RESERVED_FOR_LP_RAW,
   QUICK_LAUNCH_SOLD_SUPPLY_SHARE,
@@ -56,6 +58,8 @@ describe('QUICK_LAUNCH_PRESET', () => {
     expect(QUICK_LAUNCH_PRESET.auctionSupplyRaw).toBe(5n * 10n ** 26n)
     expect(QUICK_LAUNCH_PRESET.reservedForLpRaw).toBe(5n * 10n ** 26n)
     expect(QUICK_LAUNCH_PRESET.raiseCurrency).toBe(zeroAddress)
+    expect(QUICK_LAUNCH_PRESET.lp.fee).toBe(2_500)
+    expect(QUICK_LAUNCH_PRESET.lp.tickSpacing).toBe(25)
     expect(QUICK_LAUNCH_PRESET.lp.range).toBe('CONCENTRATED_FULL_RANGE')
     expect(QUICK_LAUNCH_PRESET.lp.lockMode).toBe('buybackBurn')
     expect(QUICK_LAUNCH_PRESET.lp.permanentTimelock).toBe(true)
@@ -436,6 +440,21 @@ describe('FDV -> price-per-token request derivation', () => {
   it('throws on a missing/invalid ETH price so callers choose their own fallback', () => {
     expect(() => getQuickLaunchFloorPricePerToken(0)).toThrow()
     expect(() => getQuickLaunchGraduationPricePerToken(Number.NaN)).toThrow()
+  })
+})
+
+describe('graduation-pool tick spacing constants', () => {
+  it('states the observed post-redeploy spacing, not the feeToTickSpacing derivation', () => {
+    // The 2026-08-05 chain-4663 redeploy mints graduation pools at spacing 25; the generic
+    // fee->spacing formula would say 50 for the 2500 tier. The preset states on-chain reality.
+    expect(QUICK_LAUNCH_POOL_TICK_SPACING).toBe(25)
+    expect(QUICK_LAUNCH_PRESET.lp.tickSpacing).toBe(QUICK_LAUNCH_POOL_TICK_SPACING)
+  })
+
+  it('grandfathers every spacing pools were ever minted at — pools are permanent', () => {
+    expect([...QUICK_LAUNCH_ALLOWED_POOL_TICK_SPACINGS]).toEqual([25, 50])
+    // The current preset value is in the allowed set.
+    expect(QUICK_LAUNCH_ALLOWED_POOL_TICK_SPACINGS).toContain(QUICK_LAUNCH_POOL_TICK_SPACING)
   })
 })
 

--- a/sdks/liquidity-launcher-sdk/src/quickLaunch.ts
+++ b/sdks/liquidity-launcher-sdk/src/quickLaunch.ts
@@ -99,6 +99,28 @@ export const QUICK_LAUNCH_GRADUATION_FDV_TOLERANCE_RATIO = 0.1
  */
 export const QUICK_LAUNCH_LP_FEE = 2_500
 
+/**
+ * V4 graduation-pool tick spacing, as passed in `MigratorParameters.poolParameters` since the
+ * 2026-08-05 chain-4663 full redeploy. Deliberately NOT the generic {@link feeToTickSpacing}
+ * derivation, which yields 50 for the {@link QUICK_LAUNCH_LP_FEE} tier: the post-redeploy
+ * Initialize census shows every quick-launch graduation pool minted at spacing 25 (295 pools in
+ * the redeploy's first day, zero new pools at 50), so the preset states the observed value rather
+ * than a formula the launch flow no longer follows.
+ */
+export const QUICK_LAUNCH_POOL_TICK_SPACING = 25
+
+/**
+ * Every tick spacing a quick-launch graduation pool has ever been minted at, newest first — the
+ * append-only grandfather set (same shape as {@link QUICK_LAUNCH_ALLOWED_GRADUATION_FDV_USD}).
+ * Pools are permanent, so a superseded spacing never leaves this list; routing/discovery consumers
+ * deriving a token's candidate launch pools must race a `(QUICK_LAUNCH_LP_FEE, spacing)` key for
+ * EVERY entry, because the token address alone cannot say which generation minted the pool.
+ * - 25: since the 2026-08-05 chain-4663 full redeploy ({@link QUICK_LAUNCH_POOL_TICK_SPACING}).
+ * - 50: every earlier generation — the {@link feeToTickSpacing} derivation of the fee, kept as a
+ *   literal so a future change to that formula cannot rewrite the historical record.
+ */
+export const QUICK_LAUNCH_ALLOWED_POOL_TICK_SPACINGS = [QUICK_LAUNCH_POOL_TICK_SPACING, 50] as const
+
 /** V4 LP price-range strategy: full-range + concentrated. */
 export const QUICK_LAUNCH_LP_RANGE: PriceRangeKind = 'CONCENTRATED_FULL_RANGE'
 
@@ -242,6 +264,8 @@ export interface QuickLaunchPreset {
   readonly graduationFdvUsd: number
   readonly lp: {
     readonly fee: number
+    /** Graduation-pool tick spacing — see {@link QUICK_LAUNCH_POOL_TICK_SPACING}. */
+    readonly tickSpacing: number
     readonly range: PriceRangeKind
     readonly lockMode: QuickLaunchLockMode
     /** Locked forever. */
@@ -270,6 +294,7 @@ export const QUICK_LAUNCH_PRESET: QuickLaunchPreset = {
   graduationFdvUsd: QUICK_LAUNCH_GRADUATION_FDV_USD,
   lp: {
     fee: QUICK_LAUNCH_LP_FEE,
+    tickSpacing: QUICK_LAUNCH_POOL_TICK_SPACING,
     range: QUICK_LAUNCH_LP_RANGE,
     lockMode: QUICK_LAUNCH_LOCK_MODE,
     permanentTimelock: true,


### PR DESCRIPTION
## Why

The 2026-08-05 chain-4663 full redeploy (#678) changed the quick-launch **graduation pool key on-chain** — pools now mint at `(fee 2500, tickSpacing 25, hookless, initialTick 198050)` — but no SDK constant describes it: `feeToTickSpacing(2500)` still derives 50, and the preset module carries `QUICK_LAUNCH_LP_FEE` with no spacing at all.

Any routing/discovery consumer deriving a token's candidate launch pools from SDK constants therefore misses every post-redeploy token. rh-cca hit exactly this — post-redeploy tokens became untradable until Uniswap/universe#38608 shipped an app-side literal `(2500, 25)` tier. The literal belongs here, in the module that already declares itself the quick-launch preset's single source of truth.

## Evidence

On-chain `Initialize` census (chain 4663, PoolManager `0x8366a39c…`, redeploy day):
- **295 pools** minted at `(2500, 25)` — first at block 28,520,117, all via the re-mined launcher `0x0000FffF…c0`
- **Zero** new pools at `(2500, 50)` since the redeploy; instant-launch `(2500, 60)` continues unchanged
- A failing token's pool quotes healthy via `(2500, 25)` and reverts via `(2500, 50)`/`(2500, 60)`

## What changed

- `QUICK_LAUNCH_POOL_TICK_SPACING` (new) → `25`. Deliberately the *observed* value, not a formula — the launch flow no longer follows the `feeToTickSpacing` derivation.
- `QUICK_LAUNCH_ALLOWED_POOL_TICK_SPACINGS` (new) → `[25, 50] as const`. Append-only grandfather set, same shape as `QUICK_LAUNCH_ALLOWED_GRADUATION_FDV_USD`: pools are permanent, so consumers must race a `(QUICK_LAUNCH_LP_FEE, spacing)` key for every entry — the token address alone cannot say which generation minted its pool. This is the export universe's `LAUNCH_POOL_TIERS` should consume in place of its literal.
- `QUICK_LAUNCH_PRESET.lp.tickSpacing` (new field) beside the existing `lp.fee`.

**Intentionally unchanged**: `feeToTickSpacing` (still the generic v3-canonical/interface derivation used elsewhere for validation) and `isQuickLaunch` (it never matched on the pool key, so classification is unaffected).

## Verification

- 220/220 tests pass, typecheck + lint clean.
- New tests pin both constants and the preset field, including the append-only guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
