### PR TITLE
fix(uniswapx-sdk): return quoteBatch/validateBatch results in the caller's order

### DIFF
--- a/.changeset/quotebatch-preserve-input-order.md
+++ b/.changeset/quotebatch-preserve-input-order.md
@@ -1,0 +1,13 @@
+---
+'@uniswap/uniswapx-sdk': patch
+---
+
+UniswapX quoters: return batch results in the caller's order. `quoteBatch` / `validateBatch` (and the Relay and V4 equivalents) misattributed results for batches that mixed orders with and without block overrides — the caller got another order's quote and validation.
+
+`getMulticallResults` dispatches each order carrying `blockOverrides` on its own `eth_call`, because a block override applies to a whole call and those orders cannot share one. It then concatenated the responses override-orders-first and returned them, discarding the caller's ordering. Since results carry no order identity, `results[i]` is the only binding to `orders[i]`, so the mismatch was silent.
+
+Results are now scattered back into their input positions. This also corrects two places that cross-referenced the permuted results against the un-permuted input array — the exclusive-filler branch of `getValidations` and `checkTerminalStates` — which could blend one order's revert data with another order's deadline, nonce, or block override into a single verdict.
+
+The reordering triggered whenever an order without block overrides preceded one with them: `[dutch, priority]` came back swapped, `[dutch, dutch, priority]` rotated all three. Homogeneous batches, single-order calls, and batches listing every override order first were already correct, so `quote()` and `validate()` were never affected. In practice this needed a batch mixing Dutch with Priority or Hybrid orders.
+
+Also skips a wasted `eth_call` that `UniswapXOrderQuoter` and `RelayOrderQuoter` fired when every order in a batch carried an override, and consolidates three copies of the batching logic into one `multicallOrdersPreservingOrder` helper.

--- a/sdks/uniswapx-sdk/src/utils/OrderQuoter.ts
+++ b/sdks/uniswapx-sdk/src/utils/OrderQuoter.ts
@@ -35,8 +35,8 @@ import { parseExclusiveFillerData, ValidationType } from "../order/validation";
 
 import { NonceManager } from "./NonceManager";
 import {
+  multicallOrdersPreservingOrder,
   MulticallResult,
-  multicallSameContractManyFunctions,
 } from "./multicall";
 
 export enum OrderValidation {
@@ -303,50 +303,22 @@ export class UniswapXOrderQuoter
   }
 
   /// Get the results of a multicall for a given function
-  /// Each order with a blockOverride is multicalled separately
+  /// Each order with a blockOverride is multicalled separately, but results are
+  /// returned in the same order as `orders`
   private async getMulticallResults(
     functionName: string,
     orders: SignedOrder[]
   ): Promise<MulticallResult[]> {
-    const ordersWithBlockOverrides = orders.filter(
-      (order) => order.order.blockOverrides
-    );
-    const promises = [];
-    ordersWithBlockOverrides.map((order) => {
-      promises.push(
-        multicallSameContractManyFunctions(
-          this.provider,
-          {
-            address: this.quoter.address,
-            contractInterface: this.quoter.interface,
-            functionName: functionName,
-            functionParams: [[order.order.serialize(), order.signature]],
-          },
-          undefined,
-          order.order.blockOverrides
-        )
-      );
-    });
-
-    const ordersWithoutBlockOverrides = orders.filter(
-      (order) => !order.order.blockOverrides
-    );
-
-    const calls = ordersWithoutBlockOverrides.map((order) => {
-      return [order.order.serialize(), order.signature];
-    });
-
-    promises.push(
-      multicallSameContractManyFunctions(this.provider, {
+    return multicallOrdersPreservingOrder(
+      this.provider,
+      {
         address: this.quoter.address,
         contractInterface: this.quoter.interface,
         functionName: functionName,
-        functionParams: calls,
-      })
+      },
+      orders,
+      (order) => [order.order.serialize(), order.signature]
     );
-
-    const results = await Promise.all(promises);
-    return results.flat();
   }
 
   get orderQuoterAddress(): string {
@@ -418,62 +390,27 @@ export class RelayOrderQuoter
   }
 
   /// Get the results of a multicall for a given function
-  /// Each order with a blockOverride is multicalled separately
+  /// Each order with a blockOverride is multicalled separately, but results are
+  /// returned in the same order as `orders`
   private async getMulticallResults(
     functionName: string,
     orders: SignedRelayOrder[]
   ): Promise<MulticallResult[]> {
-    const ordersWithBlockOverrides = orders.filter(
-      (order) => order.order.blockOverrides
-    );
-    const promises = [];
-    ordersWithBlockOverrides.map((order) => {
-      promises.push(
-        multicallSameContractManyFunctions(
-          this.provider,
-          {
-            address: this.quoter.address,
-            contractInterface: this.quoter.interface,
-            functionName: functionName,
-            functionParams: [
-              [
-                {
-                  order: order.order.serialize(),
-                  sig: order.signature,
-                },
-              ],
-            ],
-          },
-          undefined,
-          order.order.blockOverrides
-        )
-      );
-    });
-
-    const ordersWithoutBlockOverrides = orders.filter(
-      (order) => !order.order.blockOverrides
-    );
-
-    const calls = ordersWithoutBlockOverrides.map((order) => {
-      return [
+    return multicallOrdersPreservingOrder(
+      this.provider,
+      {
+        address: this.quoter.address,
+        contractInterface: this.quoter.interface,
+        functionName: functionName,
+      },
+      orders,
+      (order) => [
         {
           order: order.order.serialize(),
           sig: order.signature,
         },
-      ];
-    });
-
-    promises.push(
-      multicallSameContractManyFunctions(this.provider, {
-        address: this.quoter.address,
-        contractInterface: this.quoter.interface,
-        functionName: functionName,
-        functionParams: calls,
-      })
+      ]
     );
-
-    const results = await Promise.all(promises);
-    return results.flat();
   }
 
   private async getValidations(
@@ -788,67 +725,27 @@ export class V4OrderQuoter implements OrderQuoter<SignedV4Order, V4OrderQuote> {
 
   /// Get the results of a multicall for a given function
   /// V4 quote requires (reactor, order, sig) instead of (order, sig)
+  /// Each order with a blockOverride is multicalled separately, but results are
+  /// returned in the same order as `orders`
   private async getMulticallResults(
     provider: StaticJsonRpcProvider,
     functionName: string,
     orders: SignedV4Order[]
   ): Promise<MulticallResult[]> {
-    const ordersWithBlockOverrides = orders.filter(
-      (order) => order.order.blockOverrides
-    );
-    const promises: Promise<MulticallResult[]>[] = [];
-
-    ordersWithBlockOverrides.map((order) => {
-      promises.push(
-        multicallSameContractManyFunctions(
-          provider,
-          {
-            address: this.quoter.address,
-            contractInterface: this.quoter.interface,
-            functionName: functionName,
-            functionParams: [
-              [
-                order.order.info.reactor,
-                order.order.serialize(),
-                order.signature,
-              ],
-            ],
-          },
-          undefined,
-          order.order.blockOverrides
-        )
-      );
-    });
-
-    const ordersWithoutBlockOverrides = orders.filter(
-      (order) => !order.order.blockOverrides
-    );
-
-    const calls = ordersWithoutBlockOverrides.map((order) => {
-      return [
+    return multicallOrdersPreservingOrder(
+      provider,
+      {
+        address: this.quoter.address,
+        contractInterface: this.quoter.interface,
+        functionName: functionName,
+      },
+      orders,
+      (order) => [
         order.order.info.reactor,
         order.order.serialize(),
         order.signature,
-      ];
-    });
-
-    if (calls.length > 0) {
-      promises.push(
-        multicallSameContractManyFunctions(
-          provider,
-          {
-            address: this.quoter.address,
-            contractInterface: this.quoter.interface,
-            functionName: functionName,
-            functionParams: calls,
-          },
-          undefined
-        )
-      );
-    }
-
-    const results = await Promise.all(promises);
-    return results.flat();
+      ]
+    );
   }
 
   get orderQuoterAddress(): string {

--- a/sdks/uniswapx-sdk/src/utils/multicall.test.ts
+++ b/sdks/uniswapx-sdk/src/utils/multicall.test.ts
@@ -1,0 +1,191 @@
+import { Interface } from "@ethersproject/abi";
+import { StaticJsonRpcProvider } from "@ethersproject/providers";
+import { ethers } from "ethers";
+
+import multicall2Abi from "../../abis/multicall2.json";
+import { BlockOverrides } from "../order";
+
+import { multicallOrdersPreservingOrder } from "./multicall";
+
+const multicall2Interface = new Interface(multicall2Abi);
+// Stand-in for the real quoter: one string param per order so each call can be
+// traced back to the order that produced it
+const quoterInterface = new Interface([
+  "function quote(string id) returns (string)",
+]);
+const QUOTER_ADDRESS = "0x0000000000000000000000000000000000000001";
+
+type TestOrder = {
+  id: string;
+  order: { blockOverrides: BlockOverrides };
+};
+
+// A Dutch/Relay-shaped order: never carries block overrides
+const plain = (id: string): TestOrder => ({
+  id,
+  order: { blockOverrides: undefined },
+});
+
+// A Priority/Hybrid-shaped order: always carries block overrides
+const overridden = (id: string, blockNumber: string): TestOrder => ({
+  id,
+  order: { blockOverrides: { number: blockNumber } },
+});
+
+type SentCall = {
+  ids: string[];
+  blockOverrides: BlockOverrides;
+};
+
+// Fake provider that decodes each eth_call back into the order ids it covers and
+// echoes each id straight back as that call's returnData
+function mockProvider(sent: SentCall[]): StaticJsonRpcProvider {
+  return {
+    // ethers rejects anything without this when connecting the Multicall2 contract
+    _isProvider: true,
+    getNetwork: async () => ({ chainId: 1 }),
+    // non-empty so multicall takes the deployed Multicall2 path, whose calldata
+    // is decodable here (the deployless path wraps calls in constructor args)
+    getCode: async () => "0xdeadbeef",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    send: async (method: string, params: any[]) => {
+      expect(method).toEqual("eth_call");
+      const [, calls] = multicall2Interface.decodeFunctionData(
+        "tryAggregate",
+        params[0].data
+      );
+      const ids: string[] = calls.map(
+        (call: { callData: string }) =>
+          quoterInterface.decodeFunctionData("quote", call.callData)[0]
+      );
+      sent.push({ ids, blockOverrides: params[3] });
+
+      return multicall2Interface.encodeFunctionResult("tryAggregate", [
+        ids.map((id) => [
+          true,
+          ethers.utils.defaultAbiCoder.encode(["string"], [id]),
+        ]),
+      ]);
+    },
+  } as unknown as StaticJsonRpcProvider;
+}
+
+async function quoteIds(
+  orders: TestOrder[],
+  sent: SentCall[] = []
+): Promise<string[]> {
+  const results = await multicallOrdersPreservingOrder(
+    mockProvider(sent),
+    {
+      address: QUOTER_ADDRESS,
+      contractInterface: quoterInterface,
+      functionName: "quote",
+    },
+    orders,
+    (order) => [order.id]
+  );
+
+  return results.map(
+    (result) =>
+      ethers.utils.defaultAbiCoder.decode(["string"], result.returnData)[0]
+  );
+}
+
+describe("multicallOrdersPreservingOrder", () => {
+  describe("results line up with the input orders", () => {
+    // Orders carrying block overrides are dispatched on separate eth_calls, so
+    // any batch that interleaves the two kinds used to come back permuted
+    const cases: { name: string; orders: TestOrder[] }[] = [
+      { name: "empty batch", orders: [] },
+      { name: "single plain order", orders: [plain("a")] },
+      { name: "single overridden order", orders: [overridden("a", "0x64")] },
+      { name: "all plain", orders: [plain("a"), plain("b"), plain("c")] },
+      {
+        name: "all overridden",
+        orders: [
+          overridden("a", "0x64"),
+          overridden("b", "0x65"),
+          overridden("c", "0x66"),
+        ],
+      },
+      {
+        name: "overridden first",
+        orders: [overridden("a", "0x64"), plain("b")],
+      },
+      {
+        name: "plain first",
+        orders: [plain("a"), overridden("b", "0x64")],
+      },
+      {
+        name: "overridden last of many",
+        orders: [plain("a"), plain("b"), overridden("c", "0x64")],
+      },
+      {
+        name: "overridden first of many",
+        orders: [overridden("a", "0x64"), plain("b"), plain("c")],
+      },
+      {
+        name: "overridden sandwiched",
+        orders: [plain("a"), overridden("b", "0x64"), plain("c")],
+      },
+      {
+        name: "interleaved",
+        orders: [
+          plain("a"),
+          overridden("b", "0x64"),
+          plain("c"),
+          overridden("d", "0x65"),
+          plain("e"),
+        ],
+      },
+    ];
+
+    for (const { name, orders } of cases) {
+      it(name, async () => {
+        expect(await quoteIds(orders)).toEqual(orders.map((o) => o.id));
+      });
+    }
+  });
+
+  it("quotes each overridden order at its own block", async () => {
+    const sent: SentCall[] = [];
+    await quoteIds(
+      [plain("a"), overridden("b", "0x64"), overridden("c", "0x65")],
+      sent
+    );
+
+    expect(
+      sent.map(({ ids, blockOverrides }) => ({ ids, blockOverrides })).sort(
+        (l, r) => l.ids[0].localeCompare(r.ids[0])
+      )
+    ).toEqual([
+      { ids: ["a"], blockOverrides: undefined },
+      { ids: ["b"], blockOverrides: { number: "0x64" } },
+      { ids: ["c"], blockOverrides: { number: "0x65" } },
+    ]);
+  });
+
+  it("batches every order without overrides into a single call", async () => {
+    const sent: SentCall[] = [];
+    await quoteIds([plain("a"), overridden("b", "0x64"), plain("c")], sent);
+
+    expect(sent).toHaveLength(2);
+    expect(sent.filter((call) => !call.blockOverrides)).toEqual([
+      { ids: ["a", "c"], blockOverrides: undefined },
+    ]);
+  });
+
+  it("skips the batched call when every order carries an override", async () => {
+    const sent: SentCall[] = [];
+    await quoteIds([overridden("a", "0x64"), overridden("b", "0x65")], sent);
+
+    expect(sent).toHaveLength(2);
+    expect(sent.every((call) => call.ids.length === 1)).toEqual(true);
+  });
+
+  it("makes no calls for an empty batch", async () => {
+    const sent: SentCall[] = [];
+    expect(await quoteIds([], sent)).toEqual([]);
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/sdks/uniswapx-sdk/src/utils/multicall.ts
+++ b/sdks/uniswapx-sdk/src/utils/multicall.ts
@@ -74,6 +74,66 @@ export async function multicallSameContractManyFunctions<
   return multicall(provider, calls, stateOverrrides, blockOverrides);
 }
 
+/// Structurally matches the SignedOrder / SignedV4Order shapes without importing
+/// them, which would create a cycle with OrderQuoter
+export type OrderWithBlockOverrides = {
+  order: { blockOverrides: BlockOverrides };
+};
+
+// Multicall a batch of orders, returning results in the SAME order as `orders`.
+//
+// A block override applies to an entire eth_call, so orders carrying one cannot
+// share a call with orders quoted at a different block. Each is dispatched on its
+// own while the remaining orders share a single batched call. Results are then
+// scattered back into their original input positions: callers index results by
+// input position, and the quoters additionally cross-reference `orders[i]` when
+// classifying validation errors and checking terminal states.
+export async function multicallOrdersPreservingOrder<
+  TOrder extends OrderWithBlockOverrides,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TFunctionParams extends any[]
+>(
+  provider: StaticJsonRpcProvider,
+  params: MulticallParams & { address: string },
+  orders: TOrder[],
+  buildParams: (order: TOrder) => TFunctionParams
+): Promise<MulticallResult[]> {
+  const overrideIndices: number[] = [];
+  const plainIndices: number[] = [];
+  orders.forEach((order, i) => {
+    (order.order.blockOverrides ? overrideIndices : plainIndices).push(i);
+  });
+
+  const batches: Promise<{ indices: number[]; results: MulticallResult[] }>[] =
+    overrideIndices.map((i) =>
+      multicallSameContractManyFunctions(
+        provider,
+        { ...params, functionParams: [buildParams(orders[i])] },
+        undefined,
+        orders[i].order.blockOverrides
+      ).then((results) => ({ indices: [i], results }))
+    );
+
+  // Skip the batched call entirely when every order carries an override,
+  // otherwise it costs a round trip to quote nothing
+  if (plainIndices.length > 0) {
+    batches.push(
+      multicallSameContractManyFunctions(provider, {
+        ...params,
+        functionParams: plainIndices.map((i) => buildParams(orders[i])),
+      }).then((results) => ({ indices: plainIndices, results }))
+    );
+  }
+
+  const ordered = new Array<MulticallResult>(orders.length);
+  for (const { indices, results } of await Promise.all(batches)) {
+    indices.forEach((inputIndex, j) => {
+      ordered[inputIndex] = results[j];
+    });
+  }
+  return ordered;
+}
+
 export async function multicallSameFunctionManyContracts<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TFunctionParams extends any[] | undefined


### PR DESCRIPTION
## Problem

`quoteBatch` / `validateBatch` (and the Relay and V4 equivalents) return results in the wrong order for batches that mix orders with and without block overrides. The caller receives another order's quote and validation.

A block override applies to an entire `eth_call`, so orders carrying one can't share a call with orders quoted at a different block. `getMulticallResults` correctly fans those out — then concatenated the responses override-orders-first and returned them, discarding the caller's ordering:

```ts
const results = await Promise.all(promises);
return results.flat();   // [overrides..., non-overrides...], not input order
```

Nothing in a `UniswapXOrderQuote` identifies its order — no hash, no nonce, no index. Position in the returned array is the only binding to `orders[i]`, so the misattribution is silent at the call site.

It triggered whenever an order *without* overrides preceded one *with* them:

| Input | Returned | |
|---|---|---|
| `[dutch, priority]` | `[priority, dutch]` | swapped |
| `[dutch, dutch, priority]` | `[priority, dutch, dutch]` | all three rotated |
| `[priority, dutch]` | `[priority, dutch]` | already correct |
| homogeneous / single order | — | already correct |

`quote()` and `validate()` wrap a single order, so they were never affected.

## Fix

One index-preserving helper, `multicallOrdersPreservingOrder`, replacing three near-identical copies of the batching logic. It records which input indices each sub-call covers and scatters results back into those slots.

Two secondary bugs fall out for free. `getValidations` and `checkTerminalStates` both walk the results array while indexing into the **un**-permuted `orders` array, so they could blend one order's revert data with a different order's deadline, nonce, or block override into a single verdict — e.g. returning `ExclusivityPeriod` built from P's revert code and D's `additionalValidationData`. Realigning the results array fixes both without touching them.

The helper also skips the batched call when every order carries an override; `UniswapXOrderQuoter` and `RelayOrderQuoter` previously fired an `eth_call` with an empty call list there (V4 already guarded this).

## Tests

`quoteBatch`/`validateBatch` had **no** coverage in either the unit or integration suite. Adds 15 tests over a mocked provider that decodes each `eth_call` back to the orders it covers, asserting `results[i]` maps to `orders[i]` across every partition shape — homogeneous, both mixed orderings, sandwiched, and interleaved — plus dispatch assertions for per-order block overrides and the empty-call guard.

Verified against the old implementation: exactly the four permuted cases fail (`[D,P]`, `[D,D,P]`, `[D,P,D]`, interleaved) and the rest pass, matching the table above. Tests assert on returned *values*, not just validation enums — the `blockOverrides` branch of `checkTerminalStates` often self-corrects, so a validation-only assertion can pass green while the quotes are still rotated.

`bun test src/`: 343 pass, 0 fail. Lint and `build:types` clean.

## Impact

Not reachable today. Only DutchV2/V3 are in production flow and they never set `blockOverrides`, so the override partition is always empty. I checked the consumers — `uniswapx-service` and `gouda-bot` both call the batch API one order at a time (`gouda-bot` does zip `quotes[i]` against `orders[i]`, but only ever passes `[signedOrder]`), and `uniswapx-parameterization-api` never constructs a quoter.

Worth fixing ahead of any Priority/Hybrid rollout: `validateBatch` is exported from the package root, Priority reactors are already deployed non-zero on Base and Unichain alongside Dutch_V3, and the filler docs point third parties at `UniswapXOrderQuoter` for quoting priority orders with block overrides. External fillers batching mixed order types are the callers we can't audit or coordinate an upgrade with.

Patch bump — behaviour becomes correct, no API surface change.

## Not included

- Adding an `orderHash` to the returned quotes so attribution becomes assertable rather than positional (deferred; would turn this failure class from silent into loud).
- `multicall()` re-runs `provider.getCode()` on every invocation, so a K-override batch costs `2(K+1)` round trips. Pre-existing and unrelated.
- V4's `rpcCalls` hands every non-OK result the same shared trace array for the whole batch. Pre-existing, and changing it would alter the debug payload shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
