### PR TITLE
chore(uniswapx-sdk): rename multicallSameContractManyFunctions to ...ManyCalls

### DIFF
--- a/.changeset/rename-multicall-same-contract-helper.md
+++ b/.changeset/rename-multicall-same-contract-helper.md
@@ -1,0 +1,9 @@
+---
+'@uniswap/uniswapx-sdk': minor
+---
+
+Rename `multicallSameContractManyFunctions` to `multicallSameContractManyCalls`. The old name is still exported as a deprecated alias, so no existing import breaks.
+
+The helper resolves `functionName` to a single fragment once, then encodes one call per entry in `functionParams` — it varies the arguments of one function, not the function itself. `functionName` living in the shared `MulticallParams` base type already makes "many functions" impossible: its sibling `multicallSameFunctionManyContracts` extends the same base and varies the address instead, and that one is named accurately.
+
+No capability was missing. `multicall` is exported and takes arbitrary `{target, callData}` pairs, so heterogeneous functions and contracts were always reachable through it; these two helpers are narrow conveniences over it, one of them mislabeled.

--- a/sdks/uniswapx-sdk/src/utils/multicall.test.ts
+++ b/sdks/uniswapx-sdk/src/utils/multicall.test.ts
@@ -5,7 +5,11 @@ import { ethers } from "ethers";
 import multicall2Abi from "../../abis/multicall2.json";
 import { BlockOverrides } from "../order";
 
-import { multicallOrdersPreservingOrder } from "./multicall";
+import {
+  multicallOrdersPreservingOrder,
+  multicallSameContractManyCalls,
+  multicallSameContractManyFunctions,
+} from "./multicall";
 
 const multicall2Interface = new Interface(multicall2Abi);
 // Stand-in for the real quoter: one string param per order so each call can be
@@ -90,6 +94,38 @@ async function quoteIds(
       ethers.utils.defaultAbiCoder.decode(["string"], result.returnData)[0]
   );
 }
+
+describe("multicallSameContractManyCalls", () => {
+  it("calls one function once per entry in functionParams", async () => {
+    const sent: SentCall[] = [];
+    const results = await multicallSameContractManyCalls(mockProvider(sent), {
+      address: QUOTER_ADDRESS,
+      contractInterface: quoterInterface,
+      functionName: "quote",
+      functionParams: [["a"], ["b"], ["c"]],
+    });
+
+    expect(sent).toEqual([{ ids: ["a", "b", "c"], blockOverrides: undefined }]);
+    expect(results).toHaveLength(3);
+  });
+
+  it("is still exported under its deprecated name", async () => {
+    expect(multicallSameContractManyFunctions).toBe(
+      multicallSameContractManyCalls
+    );
+
+    // the old name has to keep working for consumers that have not migrated
+    const sent: SentCall[] = [];
+    await multicallSameContractManyFunctions(mockProvider(sent), {
+      address: QUOTER_ADDRESS,
+      contractInterface: quoterInterface,
+      functionName: "quote",
+      functionParams: [["a"]],
+    });
+
+    expect(sent).toEqual([{ ids: ["a"], blockOverrides: undefined }]);
+  });
+});
 
 describe("multicallOrdersPreservingOrder", () => {
   describe("results line up with the input orders", () => {

--- a/sdks/uniswapx-sdk/src/utils/multicall.ts
+++ b/sdks/uniswapx-sdk/src/utils/multicall.ts
@@ -40,10 +40,10 @@ type Call = {
   callData: string;
 };
 
-// Perform multiple on-chain calls in a single http request
-// return all results including errors
+// Call one function on one contract once per entry in `functionParams`, in a
+// single http request, returning all results including errors.
 // Uses deployless method to function properly even on chains with no multicall contract deployed
-export async function multicallSameContractManyFunctions<
+export async function multicallSameContractManyCalls<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TFunctionParams extends any[] | undefined
 >(
@@ -73,6 +73,15 @@ export async function multicallSameContractManyFunctions<
 
   return multicall(provider, calls, stateOverrrides, blockOverrides);
 }
+
+/**
+ * @deprecated Renamed to {@link multicallSameContractManyCalls}. This helper calls a
+ * single function once per entry in `functionParams` -- it varies the arguments, not
+ * the function, which `functionName` being a lone string already implies. To call
+ * different functions in one request, build the calls yourself and use {@link multicall}.
+ */
+export const multicallSameContractManyFunctions =
+  multicallSameContractManyCalls;
 
 /// Structurally matches the SignedOrder / SignedV4Order shapes without importing
 /// them, which would create a cycle with OrderQuoter
@@ -106,7 +115,7 @@ export async function multicallOrdersPreservingOrder<
 
   const batches: Promise<{ indices: number[]; results: MulticallResult[] }>[] =
     overrideIndices.map((i) =>
-      multicallSameContractManyFunctions(
+      multicallSameContractManyCalls(
         provider,
         { ...params, functionParams: [buildParams(orders[i])] },
         undefined,
@@ -118,7 +127,7 @@ export async function multicallOrdersPreservingOrder<
   // otherwise it costs a round trip to quote nothing
   if (plainIndices.length > 0) {
     batches.push(
-      multicallSameContractManyFunctions(provider, {
+      multicallSameContractManyCalls(provider, {
         ...params,
         functionParams: plainIndices.map((i) => buildParams(orders[i])),
       }).then((results) => ({ indices: plainIndices, results }))


### PR DESCRIPTION
Stacked on #685 — review/merge that first.

## Problem

`multicallSameContractManyFunctions` doesn't call many functions. It resolves `functionName` to a single fragment **once**, outside the loop, then encodes one call per entry in `functionParams`:

```ts
const fragment = contractInterface.getFunction(functionName);   // one function
const calls: Call[] = functionParams.map((functionParam) => {   // many arg sets
  const callData = contractInterface.encodeFunctionData(fragment, functionParam);
```

It varies the *arguments* of one function, not the function. The structural giveaway is that `functionName` lives in the shared `MulticallParams` base type, so no helper extending it can vary the function at all:

| Helper | address(es) | functionName | params | varies on |
|---|---|---|---|---|
| `...SameContractManyFunctions` | one | one | **many** | arguments |
| `...SameFunctionManyContracts` | **many** | one | one | contract |

The sibling is named accurately; this one looks like it was named by symmetry without noticing the varying axis differs.

No capability is missing — `multicall` is exported and takes arbitrary `{target, callData}` pairs, so heterogeneous functions and contracts were always reachable. These two are narrow conveniences over it, one mislabeled.

## Change

Renamed to `multicallSameContractManyCalls`. The old name stays exported as a deprecated alias:

```ts
export const multicallSameContractManyFunctions = multicallSameContractManyCalls;
```

## Nothing breaks

`Uniswap/fee-collector` imports the old name and passes it as a first-class function reference to `multicallSameContractChunked`, so this had to stay source-compatible. The emitted declaration is `typeof multicallSameContractManyCalls`, which preserves the full generic signature — every call site and value position that accepted the old name still typechecks. Added a test asserting the alias is the same reference and still executes end-to-end.

Minor bump: additive export plus a deprecation, no removal.

`bun test src/`: 345 pass, 0 fail. Lint and `build:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
