### PR TITLE
fix(universal-router-sdk): encode ACROSS_V4_DEPOSIT_V3 command input as a single tuple

### DIFF
--- a/.changeset/across-command-tuple-encoding.md
+++ b/.changeset/across-command-tuple-encoding.md
@@ -1,0 +1,5 @@
+---
+'@uniswap/universal-router-sdk': patch
+---
+
+Encode the ACROSS_V4_DEPOSIT_V3 command input as a single offset-prefixed tuple, matching ChainedActions.sol's `abi.decode(input, (AcrossV4DepositV3Params))`. The previous flat 13-value encoding reverted with empty data at the dispatcher's decode, so every payload built via `addAcrossBridge` / `swapCallParameters` `bridgeOptions` was unexecutable.

--- a/sdks/universal-router-sdk/src/utils/routerCommands.ts
+++ b/sdks/universal-router-sdk/src/utils/routerCommands.ts
@@ -80,6 +80,14 @@ const POOL_KEY_STRUCT = '(address currency0,address currency1,uint24 fee,int24 t
 const PERMIT2_TRANSFER_FROM_STRUCT = '(address from,address to,uint160 amount,address token)'
 const PERMIT2_TRANSFER_FROM_BATCH_STRUCT = PERMIT2_TRANSFER_FROM_STRUCT + '[]'
 
+// Must be encoded as a SINGLE tuple: ChainedActions.sol decodes the command
+// input with `abi.decode(input, (AcrossV4DepositV3Params))`, and because the
+// struct has a dynamic member (`bytes message`) that encoding is
+// offset-prefixed — a flat 13-value encoding of the same fields does not
+// decode and makes the router revert with empty data.
+const ACROSS_V4_DEPOSIT_V3_STRUCT =
+  '(address depositor,address recipient,address inputToken,address outputToken,uint256 inputAmount,uint256 outputAmount,uint256 destinationChainId,address exclusiveRelayer,uint32 quoteTimestamp,uint32 fillDeadline,uint32 exclusivityDeadline,bytes message,bool useNative)'
+
 export const COMMAND_DEFINITION: { [key in CommandType]: CommandDefinition } = {
   // Batch Reverts
   [CommandType.EXECUTE_SUB_PLAN]: {
@@ -237,21 +245,7 @@ export const COMMAND_DEFINITION: { [key in CommandType]: CommandDefinition } = {
   // 3rd Party Integrations
   [CommandType.ACROSS_V4_DEPOSIT_V3]: {
     parser: Parser.Abi,
-    params: [
-      { name: 'depositor', type: 'address' },
-      { name: 'recipient', type: 'address' },
-      { name: 'inputToken', type: 'address' },
-      { name: 'outputToken', type: 'address' },
-      { name: 'inputAmount', type: 'uint256' },
-      { name: 'outputAmount', type: 'uint256' },
-      { name: 'destinationChainId', type: 'uint256' },
-      { name: 'exclusiveRelayer', type: 'address' },
-      { name: 'quoteTimestamp', type: 'uint32' },
-      { name: 'fillDeadline', type: 'uint32' },
-      { name: 'exclusivityDeadline', type: 'uint32' },
-      { name: 'message', type: 'bytes' },
-      { name: 'useNative', type: 'bool' },
-    ],
+    params: [{ name: 'params', type: ACROSS_V4_DEPOSIT_V3_STRUCT }],
   },
 }
 
@@ -342,20 +336,25 @@ export class RoutePlanner {
    * @returns RoutePlanner instance for chaining
    */
   addAcrossBridge(params: AcrossV4DepositV3Params): RoutePlanner {
+    // One value, not thirteen: the command input is a single offset-prefixed
+    // tuple (ACROSS_V4_DEPOSIT_V3_STRUCT) so the contract's
+    // `abi.decode(input, (AcrossV4DepositV3Params))` can read it.
     this.addCommand(CommandType.ACROSS_V4_DEPOSIT_V3, [
-      params.depositor,
-      params.recipient,
-      params.inputToken,
-      params.outputToken,
-      params.inputAmount,
-      params.outputAmount,
-      params.destinationChainId,
-      params.exclusiveRelayer,
-      params.quoteTimestamp,
-      params.fillDeadline,
-      params.exclusivityDeadline,
-      params.message,
-      params.useNative,
+      [
+        params.depositor,
+        params.recipient,
+        params.inputToken,
+        params.outputToken,
+        params.inputAmount,
+        params.outputAmount,
+        params.destinationChainId,
+        params.exclusiveRelayer,
+        params.quoteTimestamp,
+        params.fillDeadline,
+        params.exclusivityDeadline,
+        params.message,
+        params.useNative,
+      ],
     ])
     return this
   }

--- a/sdks/universal-router-sdk/test/unit/across.test.ts
+++ b/sdks/universal-router-sdk/test/unit/across.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { BigNumber } from 'ethers'
+import { BigNumber, utils } from 'ethers'
 import { AcrossV4DepositV3Params, CONTRACT_BALANCE } from '../../src/entities/actions/across'
 import { RoutePlanner, CommandType } from '../../src/utils/routerCommands'
 
@@ -174,6 +174,63 @@ describe('Across Bridge Integration', () => {
       // Verify both bridge commands were added
       expect(planner.commands).to.equal('0x4040') // Two ACROSS_V4_DEPOSIT_V3 commands
       expect(planner.inputs.length).to.equal(2)
+    })
+  })
+  describe('command input encoding matches the contract decoder', () => {
+    // ChainedActions.sol reads the command input with
+    // `abi.decode(input, (AcrossV4DepositV3Params))` — a SINGLE tuple with a
+    // dynamic member (`bytes message`), so the encoding must be
+    // offset-prefixed. A flat 13-value encoding of the same fields does not
+    // decode (the dispatcher reverts with empty data). This decode mirrors
+    // the contract exactly and is the regression test for that bug.
+    const ACROSS_V4_DEPOSIT_V3_TUPLE =
+      'tuple(address depositor,address recipient,address inputToken,address outputToken,uint256 inputAmount,uint256 outputAmount,uint256 destinationChainId,address exclusiveRelayer,uint32 quoteTimestamp,uint32 fillDeadline,uint32 exclusivityDeadline,bytes message,bool useNative)'
+
+    const params: AcrossV4DepositV3Params = {
+      depositor: '0x0000000000000000000000000000000000000001',
+      recipient: '0x0000000000000000000000000000000000000002',
+      inputToken: WETH_MAINNET,
+      outputToken: WETH_OPTIMISM,
+      inputAmount: CONTRACT_BALANCE,
+      outputAmount: BigNumber.from('990000000000000000'),
+      destinationChainId: 10,
+      exclusiveRelayer: '0x0000000000000000000000000000000000000000',
+      quoteTimestamp: 1700000000,
+      fillDeadline: 1700003600,
+      exclusivityDeadline: 0,
+      message: '0x1234',
+      useNative: false,
+    }
+
+    it('decodes with abi.decode(input, (AcrossV4DepositV3Params)) semantics', () => {
+      const planner = new RoutePlanner()
+      planner.addAcrossBridge(params)
+
+      const [decoded] = utils.defaultAbiCoder.decode([ACROSS_V4_DEPOSIT_V3_TUPLE], planner.inputs[0])
+
+      expect(decoded.depositor).to.equal(params.depositor)
+      expect(decoded.recipient).to.equal(params.recipient)
+      expect(decoded.inputToken).to.equal(params.inputToken)
+      expect(decoded.outputToken).to.equal(params.outputToken)
+      expect(decoded.inputAmount.toString()).to.equal(CONTRACT_BALANCE.toString())
+      expect(decoded.outputAmount.toString()).to.equal('990000000000000000')
+      expect(decoded.destinationChainId.toNumber()).to.equal(10)
+      expect(decoded.exclusiveRelayer).to.equal(params.exclusiveRelayer)
+      expect(decoded.quoteTimestamp).to.equal(params.quoteTimestamp)
+      expect(decoded.fillDeadline).to.equal(params.fillDeadline)
+      expect(decoded.exclusivityDeadline).to.equal(params.exclusivityDeadline)
+      expect(decoded.message).to.equal(params.message)
+      expect(decoded.useNative).to.equal(params.useNative)
+    })
+
+    it('is offset-prefixed (single dynamic tuple), not a flat parameter list', () => {
+      const planner = new RoutePlanner()
+      planner.addAcrossBridge(params)
+
+      // Word 0 of a single dynamic-tuple encoding is the offset to the tuple
+      // body (0x20). The old flat encoding put the depositor address here.
+      const word0 = utils.hexDataSlice(planner.inputs[0], 0, 32)
+      expect(BigNumber.from(word0).toNumber()).to.equal(32)
     })
   })
 })


### PR DESCRIPTION
## PR Scope

`fix(universal-router-sdk)` — patch release.

## Description

The `ACROSS_V4_DEPOSIT_V3` (0x40) command's input is encoded as a **flat 13-value ABI list**, but `ChainedActions.sol` in the Universal Router decodes it with `abi.decode(input, (AcrossV4DepositV3Params))` — a **single tuple**. Because the struct contains a dynamic member (`bytes message`), the single-tuple encoding is offset-prefixed and the two encodings differ (for all-static structs they'd be byte-identical, which is why this is easy to miss). The dispatcher reads the first word of the flat encoding — the depositor address — as the tuple offset, jumps out of bounds, and reverts with empty data.

**Impact: every payload built via `RoutePlanner.addAcrossBridge` or `SwapRouter.swapCallParameters(..., bridgeOptions)` reverts 100% of the time on the deployed routers.** No working integration can depend on the old bytes, so this is a pure fix with no compat concern.

The fix mirrors the existing `PERMIT_STRUCT` pattern: the command definition becomes a single named-tuple param (`ACROSS_V4_DEPOSIT_V3_STRUCT`), and `addAcrossBridge` passes the fields as one tuple value.

## How Has This Been Tested?

- **New regression tests** in `test/unit/across.test.ts`:
  - decodes the planner's command input exactly as the contract does (`defaultAbiCoder.decode([tuple], input)`) and asserts field-level round-trip — this test **fails against the old flat encoding** (decode throws);
  - asserts the input is offset-prefixed (word 0 = `0x20`), i.e. a single dynamic tuple rather than a flat list.
- All pre-existing across tests pass unchanged (they assert command bytes/against counts, which don't change). Unit-suite failure count is identical to `main` before/after (the 13 pre-existing `encodeSwaps` minHopPriceX36 failures are unrelated).
- **Verified by execution against the real deployed mainnet UR 2.2.0** (`0xCb640A86855f1A828c27241bA364348de28abe66`) on an Anvil mainnet fork, as part of Uniswap/backend#10876: the tuple encoding executes end-to-end and deposits into the real Across SpokePool (`FundsDeposited` emitted); the flat encoding reverts with empty data. Full transcripts: https://github.com/Uniswap/backend/pull/10876#issuecomment-5244545754
- `bun run build` (all three tsconfigs) and prettier clean.

## Are there any breaking changes?

No. The previous encoding never executed successfully on-chain, so no consumer can be depending on it. Type surface (`AcrossV4DepositV3Params`, `addAcrossBridge`, `bridgeOptions`) is unchanged.

## (Optional) Feedback Focus

The struct field order in `ACROSS_V4_DEPOSIT_V3_STRUCT` is pinned to `ChainedActions.sol`'s `AcrossV4DepositV3Params` — reviewed against the `@uniswap/universal-router` artifact and confirmed by the fork execution above.

## (Optional) Follow Ups

The unit tests only round-trip the SDK's encoder against ethers' decoder. An execution test against the `@uniswap/universal-router` artifact (the actual dispatcher) would have caught this class of bug — worth adding to the hardhat suite when the UR artifact is wired into tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
