### PR TITLE
feat(sdk-core): add abstract (chain 2741) v3 support

### DIFF
--- a/sdks/sdk-core/src/addresses.test.ts
+++ b/sdks/sdk-core/src/addresses.test.ts
@@ -77,5 +77,10 @@ describe('addresses', () => {
       const address = SWAP_ROUTER_02_ADDRESSES(ChainId.INK)
       expect(address).toEqual('0x177778f19e89dd1012bdbe603f144088a95c4b53')
     })
+
+    it('should return the correct address for abstract', () => {
+      const address = SWAP_ROUTER_02_ADDRESSES(ChainId.ABSTRACT)
+      expect(address).toEqual('0x2cB10Ac97F2C3dAEDEaB7b72DbaEb681891f51B8')
+    })
   })
 })

--- a/sdks/sdk-core/src/addresses.ts
+++ b/sdks/sdk-core/src/addresses.ts
@@ -565,6 +565,17 @@ const INK_ADDRESSES: ChainAddresses = {
   v4QuoterAddress: '0x3972c00f7ed4885e145823eb7c655375d275a1c5',
 }
 
+// Abstract is V3-only (gov RFC "Deploy Uniswap v3 on Abstract"); no V2 or V4
+// deployment. All addresses verified on-chain against chain 2741.
+const ABSTRACT_ADDRESSES: ChainAddresses = {
+  v3CoreFactoryAddress: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1',
+  multicallAddress: '0x9CA4dcb2505fbf536F6c54AA0a77C79f4fBC35C0',
+  quoterAddress: '0x117Fc8DEf58147016f92bAE713533dDB828aBB7e',
+  nonfungiblePositionManagerAddress: '0xfA928D3ABc512383b8E5E77edd2d5678696084F9',
+  tickLensAddress: '0x9c7d30F93812f143b6Efa673DB8448EfCB9f747E',
+  swapRouter02Address: '0x2cB10Ac97F2C3dAEDEaB7b72DbaEb681891f51B8',
+}
+
 export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses> = {
   [ChainId.MAINNET]: MAINNET_ADDRESSES,
   [ChainId.OPTIMISM]: OPTIMISM_ADDRESSES,
@@ -602,6 +613,7 @@ export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses>
   [ChainId.ARC]: ARC_ADDRESSES,
   [ChainId.ROBINHOOD]: ROBINHOOD_ADDRESSES,
   [ChainId.INK]: INK_ADDRESSES,
+  [ChainId.ABSTRACT]: ABSTRACT_ADDRESSES,
 }
 
 /* V3 Contract Addresses */

--- a/sdks/sdk-core/src/chains.test.ts
+++ b/sdks/sdk-core/src/chains.test.ts
@@ -8,6 +8,7 @@ describe('getAverageBlockTimeSecs', () => {
     expect(getAverageBlockTimeSecs(ChainId.MEGAETH)).toEqual(1)
     expect(getAverageBlockTimeSecs(ChainId.ARC)).toEqual(0.48)
     expect(getAverageBlockTimeSecs(ChainId.INK)).toEqual(1)
+    expect(getAverageBlockTimeSecs(ChainId.ABSTRACT)).toEqual(0.4)
   })
 
   it('throws on unregistered chainId', () => {
@@ -24,6 +25,7 @@ describe('secondsToBlocks', () => {
     expect(secondsToBlocks(8, ChainId.ARC)).toEqual(17) // ceil(8/0.48)
     expect(secondsToBlocks(8, ChainId.ROBINHOOD)).toEqual(80) // ceil(8/0.1)
     expect(secondsToBlocks(8, ChainId.INK)).toEqual(8) // ceil(8/1)
+    expect(secondsToBlocks(8, ChainId.ABSTRACT)).toEqual(20) // ceil(8/0.4)
     expect(secondsToBlocks(1, ChainId.MAINNET)).toEqual(1) // ceil(1/12) — rounds up to a full block
   })
 

--- a/sdks/sdk-core/src/chains.ts
+++ b/sdks/sdk-core/src/chains.ts
@@ -38,6 +38,7 @@ export enum ChainId {
   ARC = 5042,
   ROBINHOOD = 4663,
   INK = 57073,
+  ABSTRACT = 2741,
 }
 
 /**
@@ -69,6 +70,7 @@ export const AVERAGE_BLOCK_TIMES_SECONDS: { [chainId: number]: number } = {
   [ChainId.ARC]: 0.48,
   [ChainId.ROBINHOOD]: 0.1,
   [ChainId.INK]: 1,
+  [ChainId.ABSTRACT]: 0.4,
 }
 
 /**
@@ -131,6 +133,7 @@ export const SUPPORTED_CHAINS = [
   ChainId.ARC,
   ChainId.ROBINHOOD,
   ChainId.INK,
+  ChainId.ABSTRACT,
 ] as const
 export type SupportedChainsType = (typeof SUPPORTED_CHAINS)[number]
 


### PR DESCRIPTION
closes #377

## what

adds **Abstract** (ZK-stack L2, chainId **2741**) to `sdk-core` with its Uniswap **V3** deployment. Abstract has V3 live per the gov RFC ["Deploy Uniswap v3 on Abstract"](https://gov.uniswap.org/t/rfc-deploy-uniswap-v3-on-abstract/25206), but it's absent from `sdk-core`, so any SDK consumer can't resolve its contract addresses.


## how

- `chains.ts`: `ChainId.ABSTRACT = 2741`, average block time (`0.4`), `SUPPORTED_CHAINS`
- `addresses.ts`: `ABSTRACT_ADDRESSES` (V3 only) + `CHAIN_TO_ADDRESSES_MAP` entry (the derived V3 maps pick it up automatically)
- tests in `chains.test.ts` + `addresses.test.ts`

## the careful part: every address verified on-chain before inclusion

The issue proposed addresses marked "(to be verified)", and its **V2 factory/router were Ethereum-mainnet placeholders** (`0x5C69…aA6f` / `0x7a25…488D`). Shipping wrong addresses in an SDK is how funds get lost, so I checked all of them against chain 2741 (`https://api.mainnet.abs.xyz`):

| contract | address | check |
|---|---|---|
| v3CoreFactory | `0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1` | deployed; `feeAmountTickSpacing(500)` = 10 ✅ |
| swapRouter02 | `0x2cB10Ac97F2C3dAEDEaB7b72DbaEb681891f51B8` | deployed; `factory()` → the v3CoreFactory ✅ |
| nftPositionManager | `0xfA928D3ABc512383b8E5E77edd2d5678696084F9` | deployed; `name()` = "Uniswap V3 Positions NFT-V1", `factory()` → v3CoreFactory ✅ |
| quoter | `0x117Fc8DEf58147016f92bAE713533dDB828aBB7e` | deployed; `factory()` → v3CoreFactory ✅ |
| multicall | `0x9CA4dcb2505fbf536F6c54AA0a77C79f4fBC35C0` | deployed ✅ |
| tickLens | `0x9c7d30F93812f143b6Efa673DB8448EfCB9f747E` | deployed ✅ |

**V2 is omitted on purpose**: the proposed V2 addresses have **no bytecode** on Abstract, and V2 was never in the RFC. 11 supported chains already ship no V2 factory (including `ZKSYNC`, the same ZK-stack family), so omitting is standard, not a gap.

Block time measured ~0.43s/block over 3000 blocks → `0.4`.

## receipts

```
$ cast chain-id --rpc-url https://api.mainnet.abs.xyz            → 2741
$ cast call <v3Factory>   "feeAmountTickSpacing(uint24)(int24)" 500   → 10
$ cast call <swapRouter02> "factory()(address)"                  → 0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1
$ cast call <posManager>   "name()(string)"                      → "Uniswap V3 Positions NFT-V1"
$ cast call <posManager>   "factory()(address)"                  → 0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1
$ cast code  <V2 factory placeholder>                            → 0x   (no code → omitted)

$ bun test    → 376 pass, 0 fail
$ bun run build → exit 0
$ eslint      → 0 warnings
```
