### PR TITLE
feat(sdk-core): currency-safe CurrencyAmount comparisons

### DIFF
--- a/.changeset/currency-safe-comparisons.md
+++ b/.changeset/currency-safe-comparisons.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/sdk-core": minor
+---
+
+`CurrencyAmount.greaterThan/equalTo/lessThan` now throw a `CURRENCY` invariant when compared against a `CurrencyAmount` of a different currency, matching the existing behavior of `add`/`subtract`. Previously these fell through to `Fraction` and silently compared raw numerators across currencies. Comparisons against a raw amount (number, `JSBI`, `Fraction`) are unchanged.

--- a/sdks/sdk-core/src/entities/fractions/currencyAmount.test.ts
+++ b/sdks/sdk-core/src/entities/fractions/currencyAmount.test.ts
@@ -112,4 +112,37 @@ describe('CurrencyAmount', () => {
       expect(amount.toExact()).toEqual('0.00123')
     })
   })
+
+  describe('#comparisons', () => {
+    const ADDRESS_TWO = '0x0000000000000000000000000000000000000002'
+    const tokenA = new Token(1, ADDRESS_ONE, 18)
+    const tokenB = new Token(1, ADDRESS_TWO, 18)
+
+    it('compares amounts of the same currency', () => {
+      const two = CurrencyAmount.fromRawAmount(tokenA, 2)
+      const one = CurrencyAmount.fromRawAmount(tokenA, 1)
+      expect(two.greaterThan(one)).toBe(true)
+      expect(one.lessThan(two)).toBe(true)
+      expect(one.equalTo(CurrencyAmount.fromRawAmount(tokenA, 1))).toBe(true)
+    })
+
+    it('still compares against a raw amount (number, JSBI) without a currency', () => {
+      const amount = CurrencyAmount.fromRawAmount(tokenA, 1)
+      const zero = CurrencyAmount.fromRawAmount(tokenA, 0)
+      expect(amount.greaterThan(0)).toBe(true)
+      expect(zero.equalTo(0)).toBe(true)
+      // raw BigintIsh (e.g. a JSBI ZERO constant) must keep working, not just the 0 literal
+      expect(zero.equalTo(JSBI.BigInt(0))).toBe(true)
+      expect(amount.greaterThan(JSBI.BigInt(0))).toBe(true)
+      expect(zero.lessThan(amount)).toBe(true)
+    })
+
+    it('throws when comparing different currencies', () => {
+      const a = CurrencyAmount.fromRawAmount(tokenA, 1)
+      const b = CurrencyAmount.fromRawAmount(tokenB, 1)
+      expect(() => a.greaterThan(b)).toThrow('CURRENCY')
+      expect(() => a.lessThan(b)).toThrow('CURRENCY')
+      expect(() => a.equalTo(b)).toThrow('CURRENCY')
+    })
+  })
 })

--- a/sdks/sdk-core/src/entities/fractions/currencyAmount.ts
+++ b/sdks/sdk-core/src/entities/fractions/currencyAmount.ts
@@ -66,6 +66,26 @@ export class CurrencyAmount<T extends Currency> extends Fraction {
     return CurrencyAmount.fromFractionalAmount(this.currency, divided.numerator, divided.denominator)
   }
 
+  // Comparisons keep the base `Fraction | BigintIsh` signature so existing
+  // callers (e.g. `amount.equalTo(ZERO)` against a raw zero) keep working, and
+  // add the same currency-safety invariant that add/subtract enforce whenever
+  // the other side is itself a CurrencyAmount - so a cross-currency comparison
+  // throws instead of silently comparing raw numerators.
+  public lessThan(other: Fraction | BigintIsh): boolean {
+    if (other instanceof CurrencyAmount) invariant(this.currency.equals(other.currency), 'CURRENCY')
+    return super.lessThan(other)
+  }
+
+  public equalTo(other: Fraction | BigintIsh): boolean {
+    if (other instanceof CurrencyAmount) invariant(this.currency.equals(other.currency), 'CURRENCY')
+    return super.equalTo(other)
+  }
+
+  public greaterThan(other: Fraction | BigintIsh): boolean {
+    if (other instanceof CurrencyAmount) invariant(this.currency.equals(other.currency), 'CURRENCY')
+    return super.greaterThan(other)
+  }
+
   public toSignificant(
     significantDigits: number = 6,
     format?: object,


### PR DESCRIPTION
closes #53

## what

`CurrencyAmount.greaterThan/equalTo/lessThan` were never overridden, so they fell through to `Fraction` with no currency check. `usdcAmount.greaterThan(daiAmount)` silently compared raw numerators across two different currencies. The sibling arithmetic methods (`add`/`subtract`/`multiply`) already guard this with `invariant(this.currency.equals(other.currency), 'CURRENCY')`.

## how

The three comparison methods now apply that same invariant when the other operand is itself a `CurrencyAmount`, so a cross-currency comparison throws `CURRENCY` instead of returning a meaningless result.

I kept the base `Fraction | BigintIsh` signature rather than narrowing to `CurrencyAmount<T> | 0` as the issue suggests, on purpose: the narrowing breaks legitimate existing call sites that compare against a raw amount. Concretely, `v2-sdk`'s `pair.reserve0.equalTo(ZERO)` (where `ZERO` is a `JSBI`, not the number literal `0`) fails to type-check under `CurrencyAmount<T> | 0`, and that raw-zero pattern is common. A runtime invariant delivers the currency safety the issue asks for without forcing a downstream migration.

The `instanceof CurrencyAmount` guard degrades gracefully: if `other` is a `CurrencyAmount` from a different copy of the package, it falls through to the base comparison (exactly the pre-fix behavior), never a wrong throw. `Percent`/`Price` extend `Fraction` (not `CurrencyAmount`), so they still compare as fractions.

## testing

- `sdk-core`: 19 tests in `currencyAmount.test.ts` pass (3 new: same-currency comparisons, raw-amount comparisons including a `JSBI` zero, and a cross-currency throw). `tsc` + `eslint` clean.
- Ran the full suites of the downstream consumers against the rebuilt `sdk-core`: `v2-sdk` (103) and `v3-sdk` (338) pass with zero failures. (`router-sdk`/`v4-sdk`/`universal-router-sdk` fail only on pre-existing workspace module-resolution, unrelated to this change - their unbuilt sibling packages.)
- Grepped the monorepo for native-vs-wrapped comparison sites (`ETH.equals(WETH)` is false, so those would newly throw): none exist.

Changeset included (`minor`), noting the behavior change.
