### PR TITLE
fix(universal-router-sdk): mask ALLOW_REVERT_FLAG bit in commandParser

### DIFF
--- a/.changeset/urs-allowrevertflag-mask.md
+++ b/.changeset/urs-allowrevertflag-mask.md
@@ -1,0 +1,5 @@
+---
+"@uniswap/universal-router-sdk": patch
+---
+
+fix: mask ALLOW_REVERT_FLAG bit in GenericCommandParser.getCommands before casting to CommandType, matching on-chain Dispatcher.sol dispatch semantics. Previously any calldata containing a flagged command (e.g. a sub-plan) threw a TypeError instead of parsing.

--- a/sdks/universal-router-sdk/src/utils/commandParser.ts
+++ b/sdks/universal-router-sdk/src/utils/commandParser.ts
@@ -9,6 +9,7 @@ import {
   V2V3_SWAP_COMMANDS_V2_1_1,
   Subparser,
   Parser,
+  ALLOW_REVERT_FLAG,
 } from '../utils/routerCommands'
 import { UniversalRouterVersion, isAtLeastV2_1_1 } from '../utils/constants'
 
@@ -130,7 +131,8 @@ export class GenericCommandParser {
 
     for (let i = 2; i < commands.length; i += 2) {
       const byte = commands.substring(i, i + 2)
-      commandTypes.push(parseInt(byte, 16) as CommandType)
+      // strip the ALLOW_REVERT_FLAG bit before treating the byte as a CommandType enum value
+      commandTypes.push((parseInt(byte, 16) & ~ALLOW_REVERT_FLAG) as CommandType)
     }
 
     return commandTypes

--- a/sdks/universal-router-sdk/src/utils/routerCommands.ts
+++ b/sdks/universal-router-sdk/src/utils/routerCommands.ts
@@ -66,7 +66,7 @@ export type CommandDefinition =
       parser: Parser.V3Actions
     }
 
-const ALLOW_REVERT_FLAG = 0x80
+export const ALLOW_REVERT_FLAG = 0x80
 const REVERTIBLE_COMMANDS = new Set<CommandType>([CommandType.EXECUTE_SUB_PLAN])
 
 const PERMIT_STRUCT =

--- a/sdks/universal-router-sdk/test/utils/commandParser.test.ts
+++ b/sdks/universal-router-sdk/test/utils/commandParser.test.ts
@@ -532,6 +532,27 @@ describe('Command Parser', () => {
     })
   }
 
+  // A sub-plan command has ALLOW_REVERT_FLAG (0x80) OR'd onto its command byte on-chain
+  // (RoutePlanner.addSubPlan); getCommands must mask that bit off before treating the
+  // byte as a CommandType enum value, or this throws a TypeError on real calldata.
+  describe('ALLOW_REVERT_FLAG masking', () => {
+    it('parses a sub-plan command with the ALLOW_REVERT_FLAG bit set without throwing', () => {
+      const subplan = new RoutePlanner().addCommand(CommandType.WRAP_ETH, [addressOne, amount])
+      const input = new RoutePlanner().addSubPlan(subplan)
+      // sanity: the encoded command byte actually carries the flag (0x21 | 0x80 = 0xa1)
+      expect(input.commands).to.equal('0xa1')
+
+      const functionSignature = 'execute(bytes,bytes[])'
+      const calldata = SwapRouter.INTERFACE.encodeFunctionData(functionSignature, [input.commands, input.inputs])
+
+      const result = CommandParser.parseCalldata(calldata)
+
+      expect(result.commands).to.have.lengthOf(1)
+      expect(result.commands[0].commandType).to.equal(CommandType.EXECUTE_SUB_PLAN)
+      expect(result.commands[0].commandName).to.equal('EXECUTE_SUB_PLAN')
+    })
+  })
+
   // V4 swaps are delegated to V4BaseActionsParser; the V2.1.1 minHopPriceX36 lives inside the
   // swap action struct, so verify it survives a full round-trip through CommandParser.
   describe('V4 per-hop slippage (V2.1.1)', () => {

--- a/sdks/universal-router-sdk/test/utils/uniswapData.ts
+++ b/sdks/universal-router-sdk/test/utils/uniswapData.ts
@@ -19,6 +19,7 @@ import { TEST_RECIPIENT_ADDRESS } from './addresses'
 import { encodeSqrtRatioX96 } from '@uniswap/v3-sdk'
 import { ZERO_ADDRESS } from '../../src/utils/constants'
 import { SwapRouter } from '../../src/swapRouter'
+import { ALLOW_REVERT_FLAG } from '../../src/utils/routerCommands'
 
 const V2_FACTORY = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
 const V2_ABI = [
@@ -211,7 +212,7 @@ export function parseCommands(calldata: string) {
   const cmdHex = commands.slice(2)
   const commandTypes: number[] = []
   for (let j = 0; j < cmdHex.length; j += 2) {
-    commandTypes.push(parseInt(cmdHex.slice(j, j + 2), 16) & 0x3f)
+    commandTypes.push(parseInt(cmdHex.slice(j, j + 2), 16) & ~ALLOW_REVERT_FLAG)
   }
   return { commandTypes, inputs }
 }


### PR DESCRIPTION
Found by inspection, no filed issue.

`GenericCommandParser.getCommands` parsed each command byte straight into a
`CommandType` enum value without stripping the `ALLOW_REVERT_FLAG` bit (`0x80`) that
`routerCommands.ts` ORs onto revertible commands like `EXECUTE_SUB_PLAN`. Real
calldata containing such a command (e.g. a sub-plan encoded as `0x21 | 0x80 =
0xa1`) has no matching entry in `commandDefinition`, so `parse()` throws
`TypeError: Cannot read properties of undefined (reading 'parser')`.

This mirrors on-chain dispatch semantics: `Commands.sol` defines
`FLAG_ALLOW_REVERT = 0x80` and `COMMAND_TYPE_MASK = 0x7f`, and `Dispatcher.sol:57`
dispatches via `uint8(commandType & Commands.COMMAND_TYPE_MASK)`. The parser should
mask the same way the contract does before treating the byte as a command type -
this PR makes it do that.

## Fix

- Export `ALLOW_REVERT_FLAG` from `routerCommands.ts` (was previously unexported;
  no other package in the monorepo depends on it, and it's not re-exported from
  `src/index.ts`, so nothing new enters the public API surface).
- In `commandParser.ts`, mask it off before the enum cast: `parseInt(byte, 16) &
  ~ALLOW_REVERT_FLAG`.
- Sibling bug, same root cause: `test/utils/uniswapData.ts`'s `parseCommands` used a
  stale `& 0x3f` mask, which already silently zeroed out `ACROSS_V4_DEPOSIT_V3 =
  0x40` on its own terms (independent of this fix - `0x40 & 0x3f === 0`). Fixed to
  use the same correct mask.

`EXECUTE_SUB_PLAN` is the only command type the SDK's own encoder can ever set this
flag on (`REVERTIBLE_COMMANDS` gates it, `addCommand` throws for `allowRevert` on
anything else), so the new test covers the one case the SDK itself can produce -
masking every byte unconditionally is still correct and contract-faithful for
arbitrary/foreign calldata, matching `Dispatcher.sol`'s own unconditional mask.

Parse output (`UniversalRouterCommand`) intentionally doesn't surface whether the
flag was set on a given command - that field never existed in the type, and adding
it would be a separate API addition, not part of this fix.

## Testing

New regression test in `commandParser.test.ts`, using the real
`RoutePlanner().addSubPlan()` codepath (not a hand-crafted byte) - builds a
WRAP_ETH sub-plan, asserts the encoded command byte is literally `0xa1`, then
asserts `CommandParser.parseCalldata` resolves it back to
`CommandType.EXECUTE_SUB_PLAN` without throwing.

Guard-validated: reverted just the `getCommands` masking, confirmed the new test
fails with the exact TypeError described above, restored, confirmed 22/22 pass in
that file. Full `hardhat test` suite: 477 passing, 1 failing - the failure is
`uniswapTrades.test.ts`'s mainnet-fork `before all` hook hitting a 403 from a public
RPC (no `FORK_URL` configured in this environment), isolated as pre-existing and
unrelated via `git stash` comparison (identical failure with zero diff applied).
`tsc --noEmit` and lint both clean. Changeset added (patch,
`@uniswap/universal-router-sdk`).
