### PR TITLE
fix(permit2-sdk): check signature-transfer nonce against the owner

### DIFF
--- a/.changeset/permit2-owner-nonce.md
+++ b/.changeset/permit2-owner-nonce.md
@@ -1,0 +1,5 @@
+---
+'@uniswap/permit2-sdk': minor
+---
+
+Check signature-transfer nonce against the permit owner. `nonceBitmap` is keyed by the EIP-712 signer, not the spender. `isPermitValid` and `validatePermit` now require `owner`.

--- a/sdks/permit2-sdk/src/providers/SignatureProvider.test.ts
+++ b/sdks/permit2-sdk/src/providers/SignatureProvider.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import { SignatureProvider } from './SignatureProvider'
 import { PermitTransferFrom, PermitBatchTransferFrom } from '../signatureTransfer'
 import { BigNumber } from '@ethersproject/bignumber'
@@ -83,7 +84,7 @@ describe('SignatureProvider', () => {
         deadline: BigNumber.from(Math.floor(Date.now() / 1000) + 3600), // 1 hour from now
       }
 
-      const isValid = await signatureProvider.isPermitValid(permit)
+      const isValid = await signatureProvider.isPermitValid(permit, owner)
       expect(typeof isValid).toBe('boolean')
     })
 
@@ -104,7 +105,7 @@ describe('SignatureProvider', () => {
         deadline: BigNumber.from(Math.floor(Date.now() / 1000) + 3600), // 1 hour from now
       }
 
-      const isValid = await signatureProvider.isPermitValid(permit)
+      const isValid = await signatureProvider.isPermitValid(permit, owner)
       expect(typeof isValid).toBe('boolean')
     })
 
@@ -119,7 +120,7 @@ describe('SignatureProvider', () => {
         deadline: BigNumber.from(Math.floor(Date.now() / 1000) - 3600), // 1 hour ago
       }
 
-      const isValid = await signatureProvider.isPermitValid(permit)
+      const isValid = await signatureProvider.isPermitValid(permit, owner)
       expect(isValid).toBe(false)
     })
   })
@@ -136,7 +137,7 @@ describe('SignatureProvider', () => {
         deadline: BigNumber.from(Math.floor(Date.now() / 1000) + 3600), // 1 hour from now
       }
 
-      const result = await signatureProvider.validatePermit(permit)
+      const result = await signatureProvider.validatePermit(permit, owner)
 
       expect(result).toHaveProperty('isUsed')
       expect(result).toHaveProperty('isExpired')
@@ -144,6 +145,29 @@ describe('SignatureProvider', () => {
       expect(typeof result.isUsed).toBe('boolean')
       expect(typeof result.isExpired).toBe('boolean')
       expect(typeof result.isValid).toBe('boolean')
+    })
+
+    it('should check the owner nonce bitmap, not the spender', async () => {
+      const nonce = BigNumber.from(123)
+      const permit: PermitTransferFrom = {
+        permitted: {
+          token,
+          amount: BigNumber.from(1000000),
+        },
+        spender,
+        nonce,
+        deadline: BigNumber.from(Math.floor(Date.now() / 1000) + 3600),
+      }
+
+      const nonceSpy = spyOn(signatureProvider, 'isNonceUsed').mockResolvedValue(true)
+      spyOn(signatureProvider, 'isExpired').mockResolvedValue(false)
+
+      const result = await signatureProvider.validatePermit(permit, owner)
+
+      expect(nonceSpy).toHaveBeenCalledWith(owner, nonce)
+      expect(nonceSpy).not.toHaveBeenCalledWith(spender, nonce)
+      expect(result.isUsed).toBe(true)
+      expect(result.isValid).toBe(false)
     })
   })
 
@@ -279,7 +303,7 @@ describe('SignatureProvider', () => {
       const isExpired = await signatureProvider.isExpired(deadline)
 
       // Validate permit
-      const isValid = await signatureProvider.isPermitValid(permit)
+      const isValid = await signatureProvider.isPermitValid(permit, owner)
 
       // All checks should be consistent
       expect(isValid).toBe(!isNonceUsed && !isExpired)

--- a/sdks/permit2-sdk/src/providers/SignatureProvider.ts
+++ b/sdks/permit2-sdk/src/providers/SignatureProvider.ts
@@ -44,21 +44,27 @@ export class SignatureProvider {
   /**
    * Check if a permit is valid (not expired and nonce not used)
    * @param permit The permit data to validate
+   * @param owner The EIP-712 signer. Permit2 nonceBitmap is keyed by owner, not spender.
    * @returns true if the permit is valid, false otherwise
    */
-  async isPermitValid(permit: PermitTransferFrom | PermitBatchTransferFrom): Promise<boolean> {
-    return (await this.validatePermit(permit)).isValid
+  async isPermitValid(permit: PermitTransferFrom | PermitBatchTransferFrom, owner: string): Promise<boolean> {
+    return (await this.validatePermit(permit, owner)).isValid
   }
 
   /**
    * Get detailed validation results for a permit
    * @param permit The permit data to validate
+   * @param owner The EIP-712 signer. Permit2 nonceBitmap is keyed by owner, not spender.
    * @returns Object containing validation results
    */
-  async validatePermit(permit: PermitTransferFrom | PermitBatchTransferFrom): Promise<NonceValidationResult> {
+  async validatePermit(
+    permit: PermitTransferFrom | PermitBatchTransferFrom,
+    owner: string
+  ): Promise<NonceValidationResult> {
+    invariant(!!owner, 'OWNER_REQUIRED')
     const [isExpiredResult, isNonceUsedResult] = await Promise.all([
       this.isExpired(permit.deadline),
-      this.isNonceUsed(permit.spender, permit.nonce),
+      this.isNonceUsed(owner, permit.nonce),
     ])
 
     return {


### PR DESCRIPTION
## PR Scope

`fix(permit2-sdk):` correctness of `isPermitValid` / `validatePermit`.

## Description

`SignatureProvider.isNonceUsed` documents its first argument as the owner and calls `permit2.nonceBitmap(owner, wordPos)`. `validatePermit` passed `permit.spender` instead.

Permit2 signature-transfer nonces are keyed by the EIP-712 signer. After the owner spends nonce N, the spender (usually a router) still has that bit unset. `isPermitValid` returned true. On-chain Permit2 still reverts `InvalidNonce`. The harmed caller is an off-chain consumer that treats this helper as the live-permit check (quotes, inventory, replay gates).

`isPermitValid` and `validatePermit` now take `owner` and check `isNonceUsed(owner, nonce)`.

Threat model: the attacker already holds a spent owner nonce and a permit that names a spender whose bitmap bit is unused. The remaining library guard is this verify API. Checking the spender turns that guard into a no-op.

## How Has This Been Tested?

Unit test spies `isNonceUsed` and asserts it is called with `owner`, not `spender`.

```
bun test src/providers/SignatureProvider.test.ts -t "owner nonce bitmap"
```

Revert-tested: putting `permit.spender` back makes that assertion fail.

`tsc -p tsconfig.types.json` clean. Existing fork-based tests need `FORK_URL` and were not re-run here. Call sites in this file now pass `owner`.

## Are there any breaking changes?

Yes, TypeScript callers must pass `owner` as the second argument. The old one-argument form checked the wrong account, so keeping that signature would keep the fail-open. If you want this titled `feat(breaking):` and a major bump, I can retitle.

## (Optional) Feedback Focus

Whether `minor` (changeset) vs `major` is the right version bump for the extra required argument.


Made with [Cursor](https://cursor.com)