### PR TITLE
feat(liquidity-launcher-sdk)!: derive permanence from the time horizon only (LP-1362)

### DIFF
--- a/.changeset/permanence-sentinel-floor.md
+++ b/.changeset/permanence-sentinel-floor.md
@@ -1,0 +1,14 @@
+---
+'@uniswap/liquidity-launcher-sdk': major
+---
+
+`isPermanentTimelock` now always judges permanence from the real time horizon past the auction end. The chain-agnostic raw-block form is removed, along with the `PERMANENT_UNLOCK_BLOCK_THRESHOLD` export it used.
+
+**Breaking:**
+
+- `PERMANENT_UNLOCK_BLOCK_THRESHOLD` is deleted.
+- `PermanentTimelockParams` no longer accepts `{unlockBlock}` alone — the block form requires `chainId` and `endBlock`. The timestamp form and the structural (`'burn'` / `'creatorFees'`) short-circuit are unchanged.
+
+**Why:** the threshold could not express "1000 years" on every chain — it was ~76,000 years at 12 s/block and only ~634 at 0.1 s — so which locks it caught depended on the chain it happened to be applied to. It also could not see a genuinely permanent lock on a slow chain at all: a 1000-year horizon is ~2.6e9 blocks at 12 s, three orders of magnitude under the 2e11 bound. The horizon is derivable wherever the auction is in hand, so the approximation had no remaining reason to exist: the only production caller (data-api's quick-launch classifier) already passed `chainId`/`endBlock`, and the serving path that motivated the raw form has both available at its call site.
+
+**One behavior change in the field.** A lock whose stored unlock block was converted at a block time the chain no longer runs at now re-derives to its true horizon. Chain 4663 has exactly one such row — auction `4663_0xC5EdF1…` (2026-07-08), horizon `PERMANENT_TIMELOCK_REQUEST_SECONDS / 12` = 262,800,000,000 blocks, i.e. the 100,000-year Permanent preset converted at 12 s/block a day before that chain's 0.1 s cadence was registered. At the real cadence it is 833 years, so it is now finite. That matches what the classifier already stored for it (`is_quick_launch = false`); previously the raw-block form made the serving path disagree with the classifier on the same lock. Verified against all 2,642 production `auction_liquidity_locks` rows: this is the only row where the two rules differ.

--- a/sdks/liquidity-launcher-sdk/src/quickLaunch.test.ts
+++ b/sdks/liquidity-launcher-sdk/src/quickLaunch.test.ts
@@ -8,7 +8,6 @@ import { resolveNewPoolTickSpacing } from './config/fees'
 import {
   PERMANENT_TIMELOCK_MIN_HORIZON_SECONDS,
   PERMANENT_TIMELOCK_REQUEST_SECONDS,
-  PERMANENT_UNLOCK_BLOCK_THRESHOLD,
   QUICK_LAUNCH_ALLOWED_GRADUATION_FDV_USD,
   QUICK_LAUNCH_ALLOWED_POOL_TICK_SPACINGS,
   QUICK_LAUNCH_DURATION_SECONDS,
@@ -276,31 +275,36 @@ describe('isPermanentTimelock — timestamp form (create flow)', () => {
   })
 })
 
-describe('isPermanentTimelock — raw-block sentinel form (chain-agnostic serving)', () => {
-  it('accepts an unlock block at the sentinel threshold', () => {
-    expect(isPermanentTimelock({ unlockBlock: PERMANENT_UNLOCK_BLOCK_THRESHOLD })).toBe(true)
+describe('isPermanentTimelock — the horizon is re-derived, not read off the raw block', () => {
+  // A stored unlock block encodes the block time believed when the lock was created. Chain 4663
+  // has one converted at 12 s/block, a day before its 0.1 s cadence was registered: auction
+  // 4663_0xC5EdF1… (2026-07-08), horizon exactly PERMANENT_TIMELOCK_REQUEST_SECONDS / 12. At the
+  // real cadence that is 833 years, so it is finite — matching what the classifier already stored
+  // for it (is_quick_launch = false).
+  const endBlock = 4_731_535n
+  const unlockBlock = endBlock + PERMANENT_TIMELOCK_REQUEST_SECONDS / 12n
+
+  it('reports a mis-converted legacy horizon as finite, on the chain it actually runs at', () => {
+    expect(isPermanentTimelock({ chainId: SupportedChainId.ROBINHOOD, endBlock, unlockBlock })).toBe(false)
   })
 
-  it('rejects an unlock block one below the sentinel threshold', () => {
-    expect(isPermanentTimelock({ unlockBlock: PERMANENT_UNLOCK_BLOCK_THRESHOLD - 1n })).toBe(false)
+  it('accepts the same request converted at the correct cadence', () => {
+    const correct = endBlock + PERMANENT_TIMELOCK_REQUEST_SECONDS * 10n // 0.1 s/block
+    expect(isPermanentTimelock({ chainId: SupportedChainId.ROBINHOOD, endBlock, unlockBlock: correct })).toBe(true)
   })
 
-  it('accepts a legacy max-uint256 sentinel unlock block', () => {
-    expect(isPermanentTimelock({ unlockBlock: 2n ** 256n - 1n })).toBe(true)
-  })
-
-  it('rejects an ordinary near-term unlock block', () => {
-    expect(isPermanentTimelock({ unlockBlock: 25_000_000n })).toBe(false)
+  it('accepts a permanent lock on a slow chain, where the raw block number is small', () => {
+    const end = 21_000_000n
+    const unlock =
+      end + BigInt(Math.ceil(PERMANENT_TIMELOCK_MIN_HORIZON_SECONDS / getBlockTimeSeconds(SupportedChainId.MAINNET)))
+    expect(unlock).toBeLessThan(3_000_000_000n) // ~2.6e9 blocks — no raw-block bound could see this
+    expect(isPermanentTimelock({ chainId: SupportedChainId.MAINNET, endBlock: end, unlockBlock: unlock })).toBe(true)
   })
 })
 
 describe('isPermanentTimelock — burn is structurally permanent', () => {
   it('accepts a burn lock at unlock block 0 (block form), as burn rows carry', () => {
     expect(isPermanentTimelock({ lockMode: 'burn', chainId: CHAIN, endBlock: END, unlockBlock: 0n })).toBe(true)
-  })
-
-  it('accepts a burn lock at unlock block 0 (sentinel form)', () => {
-    expect(isPermanentTimelock({ lockMode: 'burn', unlockBlock: 0n })).toBe(true)
   })
 
   it('accepts a burn lock regardless of the timestamp horizon', () => {
@@ -311,7 +315,9 @@ describe('isPermanentTimelock — burn is structurally permanent', () => {
     expect(isPermanentTimelock({ lockMode: 'buybackBurn', chainId: CHAIN, endBlock: END, unlockBlock: 0n })).toBe(
       false
     )
-    expect(isPermanentTimelock({ lockMode: 'timelock', unlockBlock: 0n })).toBe(false)
+    expect(isPermanentTimelock({ lockMode: 'timelock', chainId: CHAIN, endBlock: END, unlockBlock: 0n })).toBe(
+      false
+    )
   })
 })
 
@@ -320,9 +326,6 @@ describe('isPermanentTimelock — creatorFees is structurally permanent', () => 
     expect(isPermanentTimelock({ lockMode: 'creatorFees', chainId: CHAIN, endBlock: END, unlockBlock: 0n })).toBe(true)
   })
 
-  it('accepts a creatorFees position at unlock block 0 (sentinel form)', () => {
-    expect(isPermanentTimelock({ lockMode: 'creatorFees', unlockBlock: 0n })).toBe(true)
-  })
 
   it('exposes the structural set: burn and creatorFees only', () => {
     expect([...STRUCTURALLY_PERMANENT_LOCK_MODES].sort()).toEqual(['burn', 'creatorFees'])

--- a/sdks/liquidity-launcher-sdk/src/quickLaunch.ts
+++ b/sdks/liquidity-launcher-sdk/src/quickLaunch.ts
@@ -145,14 +145,9 @@ export const QUICK_LAUNCH_LOCK_MODE: QuickLaunchLockMode = 'buybackBurn'
 // ---------------------------------------------------------------------------
 // Permanence: the ONE definition of a "permanent" lock
 // ---------------------------------------------------------------------------
-// "Permanent" used to be defined independently in three places — the create
-// flow's requested horizon, the data-api classifier's threshold
-// (`PERMANENT_TIMELOCK_MIN_HORIZON_SECONDS`), and this SDK's bare
-// `permanentTimelock: true` declaration —
-// plus a fourth, chain-agnostic raw-block sentinel serving `lockedForever`
-// (data-api's `PERMANENT_UNLOCK_BLOCK_THRESHOLD`). They now all live here,
-// next to {@link QUICK_LAUNCH_LOCK_MODE}, and every consumer imports them:
-// changing one in isolation is no longer possible.
+// "Permanent" used to be defined independently across the create flow, the
+// data-api classifier and this SDK. It is one horizon now, judged past the
+// auction end, and every consumer imports it.
 
 /**
  * Minimum lock horizon past the auction end, in real seconds, for a timelock to count as
@@ -177,20 +172,6 @@ export const PERMANENT_TIMELOCK_MIN_HORIZON_SECONDS = 1000 * 365 * 86_400
  * never be classified finite, on any plausible block-time table.
  */
 export const PERMANENT_TIMELOCK_REQUEST_SECONDS = 365n * 100_000n * 86_400n
-
-/**
- * Chain-AGNOSTIC approximation: a raw unlock block at or past this threshold counts as permanent
- * without consulting the chain's block time (previously data-api's serving-side
- * `PERMANENT_UNLOCK_BLOCK_THRESHOLD`, gating the `lockedForever` proto field).
- *
- * Use the chain-aware forms of {@link isPermanentTimelock} whenever the chain id and auction end
- * are available — a single block count cannot express "1000 years" on every chain (on a 0.1s
- * chain this threshold is only ~600 years). This form exists for call sites that only have the
- * stored unlock block, and it still catches every real permanent lock: the create flow's ~100k-year
- * request converts to far more than 2e11 blocks on any chain, and legacy max-uint sentinel unlock
- * blocks trivially exceed it.
- */
-export const PERMANENT_UNLOCK_BLOCK_THRESHOLD = 200_000_000_000n
 
 /**
  * Buyback-&-burn searcher threshold: a searcher burns ~0.05% of supply to claim the accrued ETH
@@ -359,9 +340,6 @@ export function getQuickLaunchGraduationPricePerToken(ethUsdPrice: number): stri
  * 2. **Timestamp form** (`{endTimeSeconds, unlockTimeSeconds}`) — the same horizon rule over real
  *    seconds, for the create flow, which reasons in unix time *before* the liquidity service
  *    converts its request to a block number.
- * 3. **Raw-block sentinel form** (`{unlockBlock}` alone) — the chain-agnostic
- *    {@link PERMANENT_UNLOCK_BLOCK_THRESHOLD} approximation, for serving-side call sites that have
- *    only the stored unlock block. Prefer the chain-aware forms when possible.
  *
  * `lockMode` may accompany any form: `'burn'` and `'creatorFees'` are *structurally* permanent
  * (see {@link STRUCTURALLY_PERMANENT_LOCK_MODES}; such rows carry `unlock_block = 0`), so they
@@ -373,7 +351,6 @@ export type PermanentTimelockParams = {
 } & (
   | { chainId: number; endBlock: bigint; unlockBlock: bigint }
   | { endTimeSeconds: bigint | number; unlockTimeSeconds: bigint | number }
-  | { chainId?: undefined; endBlock?: undefined; unlockBlock: bigint }
 )
 
 /**
@@ -394,12 +371,8 @@ export function isPermanentTimelock(params: PermanentTimelockParams): boolean {
     return Number(params.unlockTimeSeconds) - Number(params.endTimeSeconds) >= PERMANENT_TIMELOCK_MIN_HORIZON_SECONDS
   }
   // Block form: chain-aware horizon via the chain block time.
-  if (params.chainId !== undefined && params.endBlock !== undefined) {
-    const horizonSeconds = Number(params.unlockBlock - params.endBlock) * getBlockTimeSeconds(params.chainId)
-    return horizonSeconds >= PERMANENT_TIMELOCK_MIN_HORIZON_SECONDS
-  }
-  // Sentinel form: chain-agnostic raw-block approximation.
-  return params.unlockBlock >= PERMANENT_UNLOCK_BLOCK_THRESHOLD
+  const horizonSeconds = Number(params.unlockBlock - params.endBlock) * getBlockTimeSeconds(params.chainId)
+  return horizonSeconds >= PERMANENT_TIMELOCK_MIN_HORIZON_SECONDS
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
> **Not for release this week.** Batches with further SDK changes before we cut a version. Note the changeset is **`major`** — see Breaking below.

## What

`isPermanentTimelock` now always judges permanence from the real time horizon past the auction end. The chain-agnostic raw-block form is gone.

```diff
-  if (params.chainId !== undefined && params.endBlock !== undefined) {
-    const horizonSeconds = Number(params.unlockBlock - params.endBlock) * getBlockTimeSeconds(params.chainId)
-    return horizonSeconds >= PERMANENT_TIMELOCK_MIN_HORIZON_SECONDS
-  }
-  // Sentinel form: chain-agnostic raw-block approximation.
-  return params.unlockBlock >= PERMANENT_UNLOCK_BLOCK_THRESHOLD
+  const horizonSeconds = Number(params.unlockBlock - params.endBlock) * getBlockTimeSeconds(params.chainId)
+  return horizonSeconds >= PERMANENT_TIMELOCK_MIN_HORIZON_SECONDS
```

**Breaking:**
- `PERMANENT_UNLOCK_BLOCK_THRESHOLD` deleted.
- `PermanentTimelockParams` no longer accepts `{unlockBlock}` alone; the block form requires `chainId` + `endBlock`.
- Timestamp form and the structural (`'burn'` / `'creatorFees'`) short-circuit unchanged.

## Why the raw-block form had to go

It was a single block count standing in for a duration, so its meaning changed per chain — 2e11 blocks is ~76,000 years at 12 s/block and ~634 years at 0.1 s. Two consequences:

- **It couldn't see slow-chain permanence at all.** A 1000-year horizon on a 12 s chain is ~2.6e9 blocks, three orders of magnitude *under* the 2e11 bound. No raw-block threshold can catch that without also swallowing every finite lock on the fast chains.
- **It made two surfaces disagree.** data-api's classifier already called `isPermanentTimelock` with `chainId`/`endBlock`; only the serving path used the raw form. Same lock, two answers.

And it had no caller left to protect. Across `sdks`, `backend` and `universe` there is exactly **one** production call site — `data-api/src/bl/workers/auction/quickLaunch.ts:135` — and it already passes `chainId`, `endBlock`, `unlockBlock`. The serving path the raw form was introduced for has `auction.end_block` and `auction.chain_id` in scope at the call site.

## The one row that changes

A stored unlock block encodes the block time believed *when the lock was created*. Chain 4663 has one row converted at the wrong cadence:

```
auction   4663_0xC5EdF109028fC48197aa0Ad4B750BdCBF9cab998   created 2026-07-08
horizon   262,800,000,000 blocks  ==  PERMANENT_TIMELOCK_REQUEST_SECONDS / 12  (exactly)
          → the 100,000-year Permanent preset, converted at 12 s/block
at 4663's real 0.1 s cadence  →  833 years  →  finite
```

The conversion predates 4663's `0.1` entry in `BLOCK_TIME_SECONDS_BY_CHAIN` by one day. Every 4663 permanent lock from 2026-07-13 on is `31,536,000,000,000` — exactly 1.0000× the 0.1 s conversion. This is the only row from the gap.

Critically, this is **not** a regression: the classifier already stored `is_quick_launch = false` for that auction, because it already used the chain-aware form. The raw-block threshold was what made serving claim `locked_forever: true` for a lock the classifier had already judged finite. Removing it makes the two agree.

Verified against all 2,642 production `auction_liquidity_locks` rows joined to their auctions: this is the **only** row where the raw-block and horizon rules differ.

## Tests

The sentinel describe block is replaced by three cases on the real data: the mis-converted 4663 horizon reading finite at the chain it actually runs at, the same request converted at the correct cadence reading permanent, and a permanent mainnet lock whose raw block number (~2.6e9) is far too small for any raw-block bound to have seen.

Two pre-existing tests used the removed `{lockMode, unlockBlock}` shape and now pass `chainId`/`endBlock` — the block-form equivalents were already asserted alongside them, so no coverage is lost.

- `bun test` → **230 pass / 0 fail** (15 files)
- `tsc --noEmit -p tsconfig.types.json` → clean

## Follow-up (not in this PR)

On the version bump, [Uniswap/backend#12485](https://github.com/Uniswap/backend/pull/12485)'s serving call site moves from `{lockMode, unlockBlock}` to `{lockMode, chainId, endBlock, unlockBlock}`, and its boundary test is rewritten against the horizon. Part of LP-1362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
