### PR TITLE
fix(router-sdk): fix MixedRouteSDK midPrice across native/wrapped boundaries (ROUTE-886)

### DIFF
--- a/.changeset/fix-mixed-route-midprice.md
+++ b/.changeset/fix-mixed-route-midprice.md
@@ -2,4 +2,4 @@
 '@uniswap/router-sdk': patch
 ---
 
-Fix midPrice inverting pool price across native/wrapped currency boundaries in mixed routes.
+Fix midPrice inverting pool price across native/wrapped currency boundaries in mixed routes by deriving it from the route's resolved path. Handle the same boundaries at encode time: partitionMixedRouteByProtocol now ends a section at a native/wrapped boundary (so the encoder's wrap/unwrap between sections applies) and getOutputOfPools bridges wrapped equivalents instead of throwing.

--- a/.changeset/fix-mixed-route-midprice.md
+++ b/.changeset/fix-mixed-route-midprice.md
@@ -1,0 +1,5 @@
+---
+'@uniswap/router-sdk': patch
+---
+
+Fix midPrice inverting pool price across native/wrapped currency boundaries in mixed routes.

--- a/sdks/router-sdk/src/entities/mixedRoute/route.test.ts
+++ b/sdks/router-sdk/src/entities/mixedRoute/route.test.ts
@@ -295,6 +295,35 @@ describe('MixedRoute', () => {
     const pair_0_2 = new Pair(CurrencyAmount.fromRawAmount(token0, '200'), CurrencyAmount.fromRawAmount(token2, '150'))
     const pair_0_weth = new Pair(CurrencyAmount.fromRawAmount(token0, '100'), CurrencyAmount.fromRawAmount(weth, '100'))
     const pair_1_weth = new Pair(CurrencyAmount.fromRawAmount(token1, '175'), CurrencyAmount.fromRawAmount(weth, '100'))
+    const tokenHigh = new Token(1, '0xffffffffffffffffffffffffffffffffffffffff', 18, 'th')
+    const pool_v4_1_eth_ratio = new V4Pool(
+      token1,
+      ETHER,
+      FeeAmount.MEDIUM,
+      60,
+      ADDRESS_ZERO,
+      encodeSqrtRatioX96(1, 4),
+      0,
+      TickMath.getTickAtSqrtRatio(encodeSqrtRatioX96(1, 4)),
+      []
+    )
+    const pair_weth_high = new Pair(
+      CurrencyAmount.fromRawAmount(weth, '100'),
+      CurrencyAmount.fromRawAmount(tokenHigh, '300')
+    )
+    // genuine (non-fake) ETH/WETH v4 pool with an asymmetric price: both sides
+    // wrap to WETH, so only the exact-equality checks can pick the right side
+    const pool_v4_eth_weth_genuine = new V4Pool(
+      ETHER,
+      weth,
+      FeeAmount.MEDIUM,
+      60,
+      ADDRESS_ZERO,
+      encodeSqrtRatioX96(1, 2),
+      0,
+      TickMath.getTickAtSqrtRatio(encodeSqrtRatioX96(1, 2)),
+      []
+    )
 
     describe('100% V3 pool route', () => {
       it('correct for 0 -> 1', () => {
@@ -464,6 +493,32 @@ describe('MixedRoute', () => {
     })
 
     describe('mixed route', () => {
+      it('correctly bridges WETH to native ETH between a V2 pair and a V4 pool', () => {
+        const route = new MixedRouteSDK([pair_0_weth, pool_v4_1_eth_ratio], token0, token1)
+
+        expect(route.midPrice.toFixed(4)).toEqual('0.2500')
+      })
+
+      it('correctly bridges native ETH to WETH between a V4 pool and a V2 pair', () => {
+        const route = new MixedRouteSDK([pool_v4_1_eth_ratio, pair_weth_high], token1, tokenHigh)
+
+        expect(route.midPrice.toFixed(4)).toEqual('12.0000')
+      })
+
+      it('prefers the exact currency match when a genuine ETH/WETH v4 pool receives WETH', () => {
+        // pool token0Price (WETH per ETH) = 0.5, token1Price (ETH per WETH) = 2
+        // WETH must match token1 exactly; the wrapped fallback alone would pick token0 and invert
+        const route = new MixedRouteSDK([pair_0_weth, pool_v4_eth_weth_genuine], token0, ETHER)
+
+        expect(route.midPrice.toFixed(4)).toEqual('2.0000')
+      })
+
+      it('resolves a genuine ETH/WETH v4 pool at the route start via the exact seed match', () => {
+        const route = new MixedRouteSDK([pool_v4_eth_weth_genuine, pair_0_weth], weth, token0)
+
+        expect(route.midPrice.toFixed(4)).toEqual('2.0000')
+      })
+
       it('correct for 0 -[V3]-> 1 -[V2]-> 2', () => {
         // pool_v3_0_1 midPrice = 0.2
         // pair_1_2 1 < 2, so token0 = t1, token1 = 2, so 150/200 = 0.75

--- a/sdks/router-sdk/src/entities/mixedRoute/route.test.ts
+++ b/sdks/router-sdk/src/entities/mixedRoute/route.test.ts
@@ -507,16 +507,23 @@ describe('MixedRoute', () => {
 
       it('prefers the exact currency match when a genuine ETH/WETH v4 pool receives WETH', () => {
         // pool token0Price (WETH per ETH) = 0.5, token1Price (ETH per WETH) = 2
-        // WETH must match token1 exactly; the wrapped fallback alone would pick token0 and invert
+        // WETH must match token1 exactly; matching by wrapped equivalence alone would pick token0 and invert
         const route = new MixedRouteSDK([pair_0_weth, pool_v4_eth_weth_genuine], token0, ETHER)
 
         expect(route.midPrice.toFixed(4)).toEqual('2.0000')
       })
 
-      it('resolves a genuine ETH/WETH v4 pool at the route start via the exact seed match', () => {
+      it('prices a genuine ETH/WETH v4 pool at the route start when the route begins with WETH', () => {
         const route = new MixedRouteSDK([pool_v4_eth_weth_genuine, pair_0_weth], weth, token0)
 
         expect(route.midPrice.toFixed(4)).toEqual('2.0000')
+      })
+
+      it('prices a genuine ETH/WETH v4 pool at the route start when the route begins with native ETH', () => {
+        // pool token0Price (WETH per ETH) = 0.5, then pair_weth_high 300/100 = 3
+        const route = new MixedRouteSDK([pool_v4_eth_weth_genuine, pair_weth_high], ETHER, tokenHigh)
+
+        expect(route.midPrice.toFixed(4)).toEqual('1.5000')
       })
 
       it('correct for 0 -[V3]-> 1 -[V2]-> 2', () => {

--- a/sdks/router-sdk/src/entities/mixedRoute/route.ts
+++ b/sdks/router-sdk/src/entities/mixedRoute/route.ts
@@ -109,15 +109,35 @@ export class MixedRouteSDK<TInput extends Currency, TOutput extends Currency> {
 
     const price = this.pools.slice(1).reduce(
       ({ nextInput, price }, pool) => {
-        return nextInput.equals(pool.token0)
-          ? {
-              nextInput: pool.token1,
-              price: price.multiply(pool.token0Price.asFraction),
-            }
-          : {
-              nextInput: pool.token0,
-              price: price.multiply(pool.token1Price.asFraction),
-            }
+        if (nextInput.equals(pool.token0)) {
+          return {
+            nextInput: pool.token1,
+            price: price.multiply(pool.token0Price.asFraction),
+          }
+        }
+
+        if (nextInput.equals(pool.token1)) {
+          return {
+            nextInput: pool.token0,
+            price: price.multiply(pool.token1Price.asFraction),
+          }
+        }
+
+        if (nextInput.wrapped.equals(pool.token0.wrapped)) {
+          return {
+            nextInput: pool.token1,
+            price: price.multiply(pool.token0Price.asFraction),
+          }
+        }
+
+        if (nextInput.wrapped.equals(pool.token1.wrapped)) {
+          return {
+            nextInput: pool.token0,
+            price: price.multiply(pool.token1Price.asFraction),
+          }
+        }
+
+        return invariant(false, 'PRICE_PATH') as never
       },
 
       this.pools[0].token0.equals(this.pathInput)

--- a/sdks/router-sdk/src/entities/mixedRoute/route.ts
+++ b/sdks/router-sdk/src/entities/mixedRoute/route.ts
@@ -1,5 +1,5 @@
 import invariant from 'tiny-invariant'
-import { Currency, Price, Token } from '@uniswap/sdk-core'
+import { Currency, Fraction, Price, Token } from '@uniswap/sdk-core'
 import { Pool as V4Pool } from '@uniswap/v4-sdk'
 import { getPathCurrency } from '../../utils/pathCurrency'
 import { TPool } from '../../utils/TPool'
@@ -107,49 +107,14 @@ export class MixedRouteSDK<TInput extends Currency, TOutput extends Currency> {
   public get midPrice(): Price<TInput, TOutput> {
     if (this._midPrice !== null) return this._midPrice
 
-    const price = this.pools.slice(1).reduce(
-      ({ nextInput, price }, pool) => {
-        if (nextInput.equals(pool.token0)) {
-          return {
-            nextInput: pool.token1,
-            price: price.multiply(pool.token0Price.asFraction),
-          }
-        }
-
-        if (nextInput.equals(pool.token1)) {
-          return {
-            nextInput: pool.token0,
-            price: price.multiply(pool.token1Price.asFraction),
-          }
-        }
-
-        if (nextInput.wrapped.equals(pool.token0.wrapped)) {
-          return {
-            nextInput: pool.token1,
-            price: price.multiply(pool.token0Price.asFraction),
-          }
-        }
-
-        if (nextInput.wrapped.equals(pool.token1.wrapped)) {
-          return {
-            nextInput: pool.token0,
-            price: price.multiply(pool.token1Price.asFraction),
-          }
-        }
-
-        return invariant(false, 'PRICE_PATH') as never
-      },
-
-      this.pools[0].token0.equals(this.pathInput)
-        ? {
-            nextInput: this.pools[0].token1,
-            price: this.pools[0].token0Price.asFraction,
-          }
-        : {
-            nextInput: this.pools[0].token0,
-            price: this.pools[0].token1Price.asFraction,
-          }
-    ).price
+    // this.path[i + 1] is always pool i's own currency object (the constructor pushes the
+    // pool's currency even when bridging a native/wrapped boundary), so exact equality is
+    // enough to orient each pool's price along the already-resolved path
+    const price = this.pools.reduce(
+      (price, pool, i) =>
+        price.multiply((this.path[i + 1].equals(pool.token1) ? pool.token0Price : pool.token1Price).asFraction),
+      new Fraction(1)
+    )
 
     return (this._midPrice = new Price(this.input, this.output, price.denominator, price.numerator))
   }

--- a/sdks/router-sdk/src/utils/index.test.ts
+++ b/sdks/router-sdk/src/utils/index.test.ts
@@ -1,0 +1,64 @@
+import { CurrencyAmount, Ether, Token, WETH9 } from '@uniswap/sdk-core'
+import { Pair } from '@uniswap/v2-sdk'
+import { encodeSqrtRatioX96 } from '@uniswap/v3-sdk'
+import { Pool as V4Pool } from '@uniswap/v4-sdk'
+import { ADDRESS_ZERO } from '../constants'
+import { MixedRouteSDK } from '../entities/mixedRoute/route'
+import { getOutputOfPools, partitionMixedRouteByProtocol } from './index'
+
+describe('utils', () => {
+  const SQRT_RATIO_ONE = encodeSqrtRatioX96(1, 1)
+  const ETHER = Ether.onChain(1)
+  const weth = WETH9[1]
+  const token0 = new Token(1, '0x0000000000000000000000000000000000000001', 18, 't0')
+  const token1 = new Token(1, '0x0000000000000000000000000000000000000002', 18, 't1')
+
+  const pool_v4_0_eth = new V4Pool(token0, ETHER, 0, 60, ADDRESS_ZERO, SQRT_RATIO_ONE, 0, 0)
+  const pool_v4_1_weth = new V4Pool(token1, weth, 0, 60, ADDRESS_ZERO, SQRT_RATIO_ONE, 0, 0)
+  const pool_v4_eth_weth = new V4Pool(ETHER, weth, 0, 60, ADDRESS_ZERO, SQRT_RATIO_ONE, 0, 0)
+  const pair_0_weth = new Pair(CurrencyAmount.fromRawAmount(token0, '100'), CurrencyAmount.fromRawAmount(weth, '100'))
+  const pair_1_weth = new Pair(CurrencyAmount.fromRawAmount(token1, '100'), CurrencyAmount.fromRawAmount(weth, '100'))
+
+  describe('#partitionMixedRouteByProtocol', () => {
+    it('splits two v4 pools at a native/wrapped boundary', () => {
+      const route = new MixedRouteSDK([pool_v4_0_eth, pool_v4_1_weth], token0, token1)
+
+      const sections = partitionMixedRouteByProtocol(route)
+      expect(sections).toEqual([[pool_v4_0_eth], [pool_v4_1_weth]])
+    })
+
+    it('keeps a v4 section together when connected through a genuine ETH/WETH pool', () => {
+      const route = new MixedRouteSDK([pool_v4_0_eth, pool_v4_eth_weth, pool_v4_1_weth], token0, token1)
+
+      const sections = partitionMixedRouteByProtocol(route)
+      expect(sections).toEqual([[pool_v4_0_eth, pool_v4_eth_weth, pool_v4_1_weth]])
+    })
+
+    it('still splits by protocol', () => {
+      const route = new MixedRouteSDK([pool_v4_0_eth, pair_1_weth], token0, token1)
+
+      const sections = partitionMixedRouteByProtocol(route)
+      expect(sections).toEqual([[pool_v4_0_eth], [pair_1_weth]])
+    })
+  })
+
+  describe('#getOutputOfPools', () => {
+    it('walks exact matches', () => {
+      expect(getOutputOfPools([pool_v4_0_eth], token0)).toEqual(ETHER)
+    })
+
+    it('bridges a native/wrapped boundary', () => {
+      expect(getOutputOfPools([pool_v4_0_eth, pool_v4_1_weth], token0)).toEqual(token1)
+      expect(getOutputOfPools([pair_0_weth], ETHER)).toEqual(token0)
+    })
+
+    it('prefers the exact side of a genuine ETH/WETH pool', () => {
+      expect(getOutputOfPools([pool_v4_eth_weth], ETHER)).toEqual(weth)
+      expect(getOutputOfPools([pool_v4_eth_weth], weth)).toEqual(ETHER)
+    })
+
+    it('throws for an unrelated input', () => {
+      expect(() => getOutputOfPools([pool_v4_1_weth], token0)).toThrow('PATH')
+    })
+  })
+})

--- a/sdks/router-sdk/src/utils/index.ts
+++ b/sdks/router-sdk/src/utils/index.ts
@@ -5,6 +5,9 @@ import { Pool as V4Pool } from '@uniswap/v4-sdk'
 import { MixedRouteSDK } from '../entities/mixedRoute/route'
 import { TPool } from './TPool'
 
+// `Pair.involvesToken` and `V3Pool.involvesToken` only accept a `Token`, so calling `involvesToken`
+// on the `TPool` union with a bare `Currency` (e.g. native ETH from `route.path`) fails to
+// typecheck. This checks the same token0/token1 membership but against any `Currency`.
 const poolInvolvesCurrency = (pool: TPool, currency: Currency): boolean =>
   pool.token0.equals(currency) || pool.token1.equals(currency)
 

--- a/sdks/router-sdk/src/utils/index.ts
+++ b/sdks/router-sdk/src/utils/index.ts
@@ -1,9 +1,12 @@
-import { Currency, Token } from '@uniswap/sdk-core'
+import { Currency } from '@uniswap/sdk-core'
 import { Pair } from '@uniswap/v2-sdk'
 import { Pool as V3Pool } from '@uniswap/v3-sdk'
 import { Pool as V4Pool } from '@uniswap/v4-sdk'
 import { MixedRouteSDK } from '../entities/mixedRoute/route'
 import { TPool } from './TPool'
+
+const poolInvolvesCurrency = (pool: TPool, currency: Currency): boolean =>
+  pool.token0.equals(currency) || pool.token1.equals(currency)
 
 /**
  * Utility function to return each consecutive section of Pools or Pairs in a MixedRoute
@@ -19,7 +22,10 @@ export const partitionMixedRouteByProtocol = (route: MixedRouteSDK<Currency, Cur
     if (
       (route.pools[left] instanceof V4Pool && !(route.pools[right] instanceof V4Pool)) ||
       (route.pools[left] instanceof V3Pool && !(route.pools[right] instanceof V3Pool)) ||
-      (route.pools[left] instanceof Pair && !(route.pools[right] instanceof Pair))
+      (route.pools[left] instanceof Pair && !(route.pools[right] instanceof Pair)) ||
+      // a native/wrapped boundary (e.g. a native-ETH v4 pool followed by a WETH v4 pool) needs a
+      // wrap/unwrap between sections, so it ends the section even within a single protocol
+      !poolInvolvesCurrency(route.pools[right], route.path[right])
     ) {
       acc.push(route.pools.slice(left, right))
       left = right
@@ -43,11 +49,13 @@ export const partitionMixedRouteByProtocol = (route: MixedRouteSDK<Currency, Cur
 export const getOutputOfPools = (pools: TPool[], firstInputToken: Currency): Currency => {
   const { inputToken: outputToken } = pools.reduce(
     ({ inputToken }, pool: TPool): { inputToken: Currency } => {
-      if (!pool.involvesToken(inputToken as Token)) throw new Error('PATH')
-      const outputToken: Currency = pool.token0.equals(inputToken) ? pool.token1 : pool.token0
-      return {
-        inputToken: outputToken,
-      }
+      // exact matches take priority so genuine ETH/WETH pools resolve to the correct side;
+      // the wrapped comparisons bridge native/wrapped boundaries the same way MixedRouteSDK does
+      if (pool.token0.equals(inputToken)) return { inputToken: pool.token1 }
+      if (pool.token1.equals(inputToken)) return { inputToken: pool.token0 }
+      if (pool.token0.wrapped.equals(inputToken.wrapped)) return { inputToken: pool.token1 }
+      if (pool.token1.wrapped.equals(inputToken.wrapped)) return { inputToken: pool.token0 }
+      throw new Error('PATH')
     },
     { inputToken: firstInputToken }
   )


### PR DESCRIPTION
`MixedRouteSDK.midPrice` selects the direction of each pool price with an exact currency equality check. When a route crosses a native/wrapped boundary, for example a v2 WETH pair followed by a v4 pool that holds native ETH, the exact check fails. The reducer then multiplies by the inverted pool price.

This caused a production incident on Robinhood Chain. A MIXED route went token to WETH on a v2 pair, then through a native ETH v4 pool. The mid price came out 13 orders of magnitude too small. The computed price impact was about -1e14 percent instead of +90 percent. The consumer clamped the value to -100 percent and the price impact warning never fired. Internal reference: ROUTE-886.

The constructor's tokenPath loop already resolves this boundary. The `midPrice` getter now matches it. The reducer checks exact equality against token0 and token1 first, then falls back to wrapped equality. If nothing matches, it throws `PRICE_PATH` instead of multiplying a wrong price with no error. The exact checks stay first so a genuine ETH/WETH pool keeps an unambiguous direction.

Tests added:

- Two regression tests that pin the inversion in both directions. Against the old code they produce 4.0000 instead of 0.2500 and 1.3333 instead of 12.0000.
- Two tests with a genuine (non-fake) ETH/WETH v4 pool at an asymmetric price. Both sides of that pool wrap to WETH, so these pin the exact-before-wrapped ordering.

Changeset: patch bump for @uniswap/router-sdk.
