### PR TITLE
fix(uniswapx-sdk): unsigned v3 dutch order serializes each output's own relativeBlocks

### DIFF
--- a/.changeset/fix-unsigned-v3dutchorder-output-blocks.md
+++ b/.changeset/fix-unsigned-v3dutchorder-output-blocks.md
@@ -1,0 +1,9 @@
+---
+'@uniswap/uniswapx-sdk': patch
+---
+
+Fixed `UnsignedV3DutchOrder.serialize()` writing the input curve's encoded `relativeBlocks` into every output instead of each output's own, so a decoded output carried the wrong decay block schedule whenever an output curve's `relativeBlocks` differed from the input's. `CosignedV3DutchOrder.serialize()` already encoded this correctly per output; `UnsignedV3DutchOrder.serialize()` now matches it.
+
+`hash()`/`witnessInfo()` already encoded each output's own `relativeBlocks` correctly, so this bug did not affect the signed digest — it was confined to the serialized byte string produced by `serialize()`. No production caller of `UnsignedV3DutchOrder.serialize()` was identified during this fix; both existing round-trip tests in `V3DutchOrder.test.ts` constructed a `CosignedV3DutchOrder` (the already-correct sibling), so `UnsignedV3DutchOrder.serialize()` itself was never exercised by any prior test.
+
+Note: an order already serialized under the old (buggy) code will still decode with the wrong output block schedule after this fix — this only corrects newly-serialized orders, it cannot retroactively repair previously-persisted bytes.

--- a/sdks/uniswapx-sdk/src/order/V3DutchOrder.test.ts
+++ b/sdks/uniswapx-sdk/src/order/V3DutchOrder.test.ts
@@ -83,6 +83,44 @@ describe("V3DutchOrder", () => {
         expect(parsed.info).to.deep.eq(orderInfo);
     });
 
+    it("UnsignedV3DutchOrder.serialize() encodes each output's own relativeBlocks, not the input's", () => {
+        const orderInfo = getFullOrderInfo({
+            input: {
+                token: INPUT_TOKEN,
+                startAmount: RAW_AMOUNT,
+                curve: {
+                    relativeBlocks: [1, 2, 3, 4],
+                    relativeAmounts: [BigInt(1), BigInt(2), BigInt(3), BigInt(4)],
+                },
+                maxAmount: RAW_AMOUNT,
+                adjustmentPerGweiBaseFee: BigNumber.from(0),
+            },
+            outputs: [
+                {
+                    token: OUTPUT_TOKEN,
+                    startAmount: RAW_AMOUNT,
+                    curve: {
+                        // deliberately different from the input curve above, so the
+                        // bug (input's blocks bleeding into every output) is visible
+                        relativeBlocks: [5, 10, 15, 20],
+                        relativeAmounts: [BigInt(1), BigInt(2), BigInt(3), BigInt(4)],
+                    },
+                    recipient: ethers.constants.AddressZero,
+                    minAmount: RAW_AMOUNT.sub(4),
+                    adjustmentPerGweiBaseFee: BigNumber.from(0),
+                },
+            ],
+        });
+        // UnsignedV3DutchOrder specifically: both existing round-trip tests above
+        // construct a CosignedV3DutchOrder, whose serialize() already encodes each
+        // output's own relativeBlocks correctly, so they never exercised this bug.
+        const order = new UnsignedV3DutchOrder(orderInfo, CHAIN_ID);
+        const serialized = order.serialize();
+        const parsed = UnsignedV3DutchOrder.parse(serialized, CHAIN_ID);
+        expect(parsed.info.input.curve.relativeBlocks).to.deep.eq([1, 2, 3, 4]);
+        expect(parsed.info.outputs[0].curve.relativeBlocks).to.deep.eq([5, 10, 15, 20]);
+    });
+
     it("Parses a serialized v3 order with negative relativeAmounts", () => {
         const orderInfo = getFullOrderInfo({
             outputs: [

--- a/sdks/uniswapx-sdk/src/order/V3DutchOrder.ts
+++ b/sdks/uniswapx-sdk/src/order/V3DutchOrder.ts
@@ -195,7 +195,7 @@ export class UnsignedV3DutchOrder implements OffChainOrder {
      * @inheritdoc order
      */
     serialize(): string {
-        const encodedRelativeBlocks = encodeRelativeBlocks(
+        const encodedInputRelativeBlocks = encodeRelativeBlocks(
             this.info.input.curve.relativeBlocks
         );
         const abiCoder = new ethers.utils.AbiCoder();
@@ -214,14 +214,17 @@ export class UnsignedV3DutchOrder implements OffChainOrder {
                 [
                     this.info.input.token,
                     this.info.input.startAmount,
-                    [encodedRelativeBlocks, this.info.input.curve.relativeAmounts],
+                    [encodedInputRelativeBlocks, this.info.input.curve.relativeAmounts],
                     this.info.input.maxAmount,
                     this.info.input.adjustmentPerGweiBaseFee,
                 ],
                 this.info.outputs.map((output) => [
                     output.token,
                     output.startAmount,
-                    [encodedRelativeBlocks, output.curve.relativeAmounts],
+                    [
+                        encodeRelativeBlocks(output.curve.relativeBlocks),
+                        output.curve.relativeAmounts,
+                    ],
                     output.recipient,
                     output.minAmount,
                     output.adjustmentPerGweiBaseFee,


### PR DESCRIPTION
## What

`UnsignedV3DutchOrder.serialize()` writes the **input** curve's encoded `relativeBlocks` into **every output**, instead of each output's own. `CosignedV3DutchOrder.serialize()` (same file, line ~557) already does per-output encoding correctly — this fix brings `UnsignedV3DutchOrder.serialize()` in line with it.

```ts
// before — one shared encoding, reused for every output
const encodedRelativeBlocks = encodeRelativeBlocks(this.info.input.curve.relativeBlocks);
...
this.info.outputs.map((output) => [
    output.token, output.startAmount,
    [encodedRelativeBlocks, output.curve.relativeAmounts],   // input's blocks + this output's amounts
    ...
```

## Repro (real code, not described)

Input curve `relativeBlocks: [1,2,3,4]`, output curve `relativeBlocks: [5,10,15,20]`:

```
UNSIGNED input blocks written : [ 1, 2, 3, 4 ]
UNSIGNED output blocks written: [ 5, 10, 15, 20 ]
UNSIGNED output blocks READ BACK: [ 1, 2, 3, 4 ]        <- wrong, this is the input's
COSIGNED (control) output blocks READ BACK: [ 5, 10, 15, 20 ]   <- correct sibling
```

## Why the existing tests never caught it

Both round-trip tests in `V3DutchOrder.test.ts` construct a `CosignedV3DutchOrder` — the sibling that already encodes correctly — so `UnsignedV3DutchOrder.serialize()` itself was never exercised by any prior test. The one test touching `UnsignedV3DutchOrder` only calls `fromJSON` and asserts two `startAmount` strings, never `relativeBlocks`.

Added a new test constructing `UnsignedV3DutchOrder` directly with **differing** input/output curves (a shared curve would make the bug invisible), asserting each side round-trips its own blocks.

## Severity — read this before assuming a signing bug

I checked `hash()`/`witnessInfo()` (the function `_TypedDataEncoder` hashes for signing) and confirmed it already encodes each output's own `relativeBlocks` correctly:

```ts
baseOutputs: this.info.outputs.map((output) => ({
    ...
    curve: { relativeBlocks: encodeRelativeBlocks(output.curve.relativeBlocks), ... },
```

So **this is not a signing-forgery path** — the signed digest was always correct. The corruption is confined to the byte string `serialize()` produces (storage/transport/pre-cosign quoting), not to what gets signed.

I did not identify a production caller of `UnsignedV3DutchOrder.serialize()` in this repo — flagging as an open dependency rather than a demonstrated live-money bug.

One caveat worth noting: an order already serialized under the buggy code will still decode with the wrong output block schedule after this fix lands — it corrects newly-serialized orders only, it can't retroactively repair previously-persisted bytes.

## Collision check

Open PR #705 touches the same file (`CosignedV3DutchOrder.resolve()`, `encodeRelativeBlocks`/`decodeRelativeBlocks` range checks) but never touches `UnsignedV3DutchOrder.serialize()` (lines 197-233) — confirmed via `gh pr diff 705` before starting, file-level overlap only, no hunk conflict expected.

## Testing

- New test: genuine red-before/green-after via `git stash` — fails with `expected [ 1, 2, 3, 4 ] to deeply equal [ 5, 10, 15, 20 ]` on unfixed code, passes after.
- Full `uniswapx-sdk` unit suite: `351/351` pass (`bun test src/`).
- `tsc --noEmit -p tsconfig.cjs.json`: clean.
- `bun run lint`: **currently broken on unmodified `main`** — `eslint src --ext .ts` fails with `Invalid option '--ext'` because the installed eslint (v8.57.1) auto-detects flat-config mode from... actually no `eslint.config.*`/`.eslintrc*` file exists anywhere in the repo at all. Confirmed this is pre-existing and unrelated to this diff by stashing my changes and re-running on a clean tree — identical failure. Not fixed here, out of scope for this PR; flagging for a maintainer.

Codex reviewed the diff adversarially: verdict "no findings," confirmed the fix is complete (no sibling class has the same pattern), the new test is non-vacuous, and independently re-ran the full order test suite (62/62 pass) as part of its own verification.

## Risk

Low. Change is additive-correct (each output now encodes its own already-present data instead of borrowed data) with no change to types, no change to `hash()`, no change to any other class.
