### PR TITLE
fix(sdk-core): sqrt fast path rounds up at perfect-square-minus-one boundaries

### DIFF
--- a/.changeset/fix-sqrt-fast-path-boundary-rounding.md
+++ b/.changeset/fix-sqrt-fast-path-boundary-rounding.md
@@ -1,0 +1,9 @@
+---
+'@uniswap/sdk-core': patch
+---
+
+Fixed `sqrt()`'s float fast path (values below `Number.MAX_SAFE_INTEGER`) returning a result one too high for inputs exactly one less than a perfect square, e.g. `sqrt(4503599761588224)` previously returned `67108865` instead of the correct `67108864`. `Math.sqrt` is correctly-rounded to the nearest double, not to the true integer square root, so for an `n` whose exact mathematical square root is extremely close to an integer from below, the rounded double can land exactly on that integer, and `Math.floor` no longer has any fractional part to floor away.
+
+The existing `'correct for 0-1000'` test asserted `sqrt(i)` equals `Math.floor(Math.sqrt(i))` — the same computation the fast path performs internally, so it was true by construction for any implementation, correct or not, and never exercised this boundary. Added a regression test checking the actual mathematical definition of `floor(sqrt(n))` (`result^2 <= n < (result+1)^2`, via exact JSBI integer arithmetic) against the known failing case plus a spread of `k^2 - 1` inputs across the fast-path range, including its upper edge.
+
+Real-world impact is narrow: the bug requires `n` to land exactly one below a perfect square (roughly 29% of such `k^2-1` values in the affected range hit it, but that shape itself is rare among arbitrary inputs — roughly 1 in 3×10^8 uniformly random values in range). The known consumers, v2-sdk's `getLiquidityMinted`/`getLiquidityValue`, would over-report by 1 wei of liquidity relative to UniswapV2's on-chain `Babylonian.sqrt` (which is exact) only when hit.

--- a/sdks/sdk-core/src/utils/sqrt.test.ts
+++ b/sdks/sdk-core/src/utils/sqrt.test.ts
@@ -1,6 +1,6 @@
 import JSBI from 'jsbi'
 import { MaxUint256 } from '../constants'
-import { sqrt } from './sqrt'
+import { MAX_SAFE_INTEGER, sqrt } from './sqrt'
 
 describe('#sqrt', () => {
   it('correct for 0-1000', () => {
@@ -22,5 +22,51 @@ describe('#sqrt', () => {
 
   it('correct for MaxUint256', () => {
     expect(sqrt(MaxUint256)).toEqual(JSBI.BigInt('340282366920938463463374607431768211455'))
+  })
+
+  // Regression: for values just below Number.MAX_SAFE_INTEGER, the fast path's
+  // Math.floor(Math.sqrt(n)) can round the *floating-point* square root up
+  // past the true integer floor, since Math.sqrt is correctly-rounded to the
+  // nearest double rather than to the true (irrational) mathematical root.
+  // These assertions check the actual definition of floor(sqrt(n)) -
+  // result^2 <= n < (result+1)^2 - via exact JSBI integer arithmetic, not
+  // against Math.sqrt itself (which is the thing that was wrong).
+  it('correct at the Number.MAX_SAFE_INTEGER boundary, including a known rounding case', () => {
+    const isExactFloor = (n: JSBI, result: JSBI): boolean => {
+      const resultSquared = JSBI.multiply(result, result)
+      const nextSquared = JSBI.multiply(JSBI.add(result, JSBI.BigInt(1)), JSBI.add(result, JSBI.BigInt(1)))
+      return JSBI.lessThanOrEqual(resultSquared, n) && JSBI.lessThan(n, nextSquared)
+    }
+
+    // n = 67108865^2 - 1: Math.sqrt(n) rounds to exactly 67108865.0 in double
+    // precision, so Math.floor(Math.sqrt(n)) previously returned 67108865,
+    // whose square (4503599761588225) exceeds n - the true floor is 67108864.
+    const knownCase = JSBI.BigInt('4503599761588224')
+    const knownResult = sqrt(knownCase)
+    expect(knownResult).toEqual(JSBI.BigInt('67108864'))
+    expect(isExactFloor(knownCase, knownResult)).toBe(true)
+
+    // The bug only manifests for n exactly one less than a perfect square
+    // (n = k^2 - 1), where Math.sqrt(n)'s correctly-rounded double happens to
+    // round up to exactly k.0 - about 29% of such k^2-1 values in this range
+    // trigger it. A sweep of *arbitrary* n near MAX_SAFE_INTEGER (as opposed
+    // to values specifically of this shape) would not reproduce the bug at
+    // all, since it depends on n's distance from the nearest perfect square,
+    // not on n's magnitude - confirmed by re-deriving this independently
+    // rather than assuming it. Sweep k across a wide span of the fast-path
+    // range, including near its very top (k close to sqrt(MAX_SAFE_INTEGER)
+    // ~= 94906265, where k^2 and (k+1)^2 can themselves approach or exceed
+    // MAX_SAFE_INTEGER - isExactFloor above still checks them exactly, via
+    // JSBI, not via a second float computation).
+    const sampleKs = [
+      2, 3, 4, 10, 100, 1000, 65536, 1_000_000, 67108864, 67108865, 67108866,
+      94906263, 94906264, 94906265, 94906266,
+    ]
+    for (const k of sampleKs) {
+      const n = JSBI.subtract(JSBI.multiply(JSBI.BigInt(k), JSBI.BigInt(k)), JSBI.BigInt(1))
+      if (JSBI.lessThan(n, JSBI.BigInt(0)) || !JSBI.lessThan(n, MAX_SAFE_INTEGER)) continue
+      const result = sqrt(n)
+      expect(isExactFloor(n, result)).toBe(true)
+    }
   })
 })

--- a/sdks/sdk-core/src/utils/sqrt.ts
+++ b/sdks/sdk-core/src/utils/sqrt.ts
@@ -16,7 +16,29 @@ export function sqrt(value: JSBI): JSBI {
 
   // rely on built in sqrt if possible
   if (JSBI.lessThan(value, MAX_SAFE_INTEGER)) {
-    return JSBI.BigInt(Math.floor(Math.sqrt(JSBI.toNumber(value))))
+    const n = JSBI.toNumber(value)
+    // Math.sqrt is correctly-rounded to the nearest double, not to the true
+    // integer square root, so Math.floor(Math.sqrt(n)) can be one too high
+    // when the true (irrational) square root is extremely close to an
+    // integer from below - e.g. n = 4503599761588224 rounds up to 67108865,
+    // whose square (4503599761588225) exceeds n. Correct the boundary with
+    // exact integer arithmetic: with a correctly-rounded Math.sqrt, the
+    // initial estimate can only be exact or one too high in this range, so
+    // the decrement loop below runs at most once; the increment loop is
+    // defensive.
+    //
+    // z*z is always exactly representable as a JS number here: n < MAX_SAFE_
+    // INTEGER (2^53 - 1) by the guard above, so z = floor(sqrt(n)) is always
+    // < sqrt(2^53), meaning z*z < 2^53 and is exact regardless of parity.
+    // (z+1)*(z+1) can exceed 2^53 - 1 only in the single case z = 94906265
+    // (the maximum z reachable in this range), where z+1 = 94906266 is even
+    // - so (z+1)*(z+1) is a multiple of 4 and stays exactly representable in
+    // the [2^53, 2^54) range, where doubles can only exactly represent even
+    // integers.
+    let z = Math.floor(Math.sqrt(n))
+    while (z * z > n) z--
+    while ((z + 1) * (z + 1) <= n) z++
+    return JSBI.BigInt(z)
   }
 
   let z: JSBI


### PR DESCRIPTION
## What

`sqrt()`'s float fast path (`value < Number.MAX_SAFE_INTEGER`) returns a result one too high when `n` is exactly one less than a perfect square. `Math.sqrt` is correctly-rounded to the nearest representable double, not to the true mathematical square root — so for an `n` whose true square root is extremely close to (but just below) an integer, the correctly-rounded double can land exactly *on* that integer, and `Math.floor` has nothing left to floor away.

```
sqrt(4503599761588224) -> 67108865   (before)
sqrt(4503599761588224) -> 67108864   (after, correct: 67108864^2 = 4503599627370496 <= n < 4503599761588225 = 67108865^2)
```

## Why the existing test never caught it

```js
it('correct for 0-1000', () => {
  for (let i = 0; i < 1000; i++) {
    expect(sqrt(JSBI.BigInt(i))).toEqual(JSBI.BigInt(Math.floor(Math.sqrt(i))))
  }
})
```

The expectation IS the implementation for the fast path — `Math.floor(Math.sqrt(i))` is exactly what `sqrt()` computes internally, so this test is true by construction for any fast-path implementation, correct or not. It also never reaches the boundary: it only covers `i < 1000`, far below where doubles start losing precision relative to the integers they approximate.

## Fix

Added an integer-arithmetic correction after the float estimate:

```ts
let z = Math.floor(Math.sqrt(n))
while (z * z > n) z--
while ((z + 1) * (z + 1) <= n) z++
return JSBI.BigInt(z)
```

With a correctly-rounded `Math.sqrt`, the float estimate can only be exact or one too high in this range, so the decrement loop runs at most once; the increment loop is defensive.

## Exactness of the correction (Codex caught a real gap here — see below)

`z*z` is always exactly representable: since `n < Number.MAX_SAFE_INTEGER` (2^53 - 1) by the fast-path guard, `z = floor(sqrt(n)) < sqrt(2^53)`, so `z*z < 2^53`, always exact regardless of parity.

`(z+1)*(z+1)` can exceed `2^53 - 1` only in the single edge case `z = 94906265` (the maximum `z` reachable in this range) — and `z+1 = 94906266` happens to be even there, so `(z+1)*(z+1)` is a multiple of 4 and stays exactly representable in the `[2^53, 2^54)` range, where doubles can only exactly represent even integers. Verified this numerically before writing the comment, not just asserted it.

## Testing

New test checks the actual mathematical definition of `floor(sqrt(n))` (`result^2 <= n < (result+1)^2`, via exact JSBI comparisons — not against `Math.sqrt` itself, which is the thing that was wrong) against:
- the known failing case (`4503599761588224`)
- a spread of `k^2 - 1` inputs across the fast-path range, including its upper edge near `sqrt(MAX_SAFE_INTEGER)`

Genuine red-before/green-after via `git stash`: fails with `expected 67108864, received 67108865` on unfixed code, passes after.

- Full `sdk-core` unit suite: `376/376` pass.
- `tsc --noEmit -p tsconfig.cjs.json`: clean.

## What Codex caught in review (both fixed before this PR was opened)

Ran Codex adversarially against the diff. It found two real issues in my first draft, both corrected:

1. **My initial regression test was misleading.** I'd swept 2048 arbitrary values near `MAX_SAFE_INTEGER`, but the bug only manifests for `n` of the specific shape `k^2 - 1`, not for arbitrary `n` near that magnitude — Codex ran the sweep itself and confirmed `0/2048` reproduced the bug. Replaced it with a sweep of actual `k^2 - 1` boundary values (see Testing above).
2. **My initial implementation comment overclaimed exactness reasoning** (referenced a nonexistent `z*n` term, and didn't justify why `(z+1)^2` staying exact wasn't a coincidence). Rewrote it with the numerically-verified argument above.

## Severity

Real-world impact is narrow, stated honestly: the bug requires `n` to land exactly one below a perfect square. About 29% of `k^2-1`-shaped values in the affected range hit it, but that shape itself is rare among arbitrary inputs (~1 in 3×10^8 for a uniformly random value in range). The known consumers — v2-sdk's `getLiquidityMinted`/`getLiquidityValue` — would over-report by 1 wei of liquidity relative to UniswapV2's on-chain `Babylonian.sqrt` (exact) only when hit.

## Risk

Low. Fast path only; the large-integer Newton's-method path (`value >= MAX_SAFE_INTEGER`) is untouched. No change to the function's public signature or error behavior.
