### PR TITLE
feat(liquidity-launcher-sdk): add Arc (5042) deployment addresses

### DIFF
--- a/.changeset/arc-liquidity-launcher-addresses.md
+++ b/.changeset/arc-liquidity-launcher-addresses.md
@@ -1,0 +1,5 @@
+---
+'@uniswap/liquidity-launcher-sdk': minor
+---
+
+Add Arc (5042) to the deployment registries: launcher stack (redeployed LiquidityLauncher, LBPStrategy, shared TokenSplitter, UniversalRouterStrategy, v4 PositionManager) and the Instant Launch generation (fees-on/fees-off strategy + FeeSplitter pairs, UERC20BeneficiaryVault, CompoundingClaimRecipient). Arc deploys no token factory, so new-token launches stay unsupported there (`selectTokenFactory`/`getInstantLaunchAddresses` return undefined); everything else resolves.

--- a/sdks/liquidity-launcher-sdk/src/addresses.test.ts
+++ b/sdks/liquidity-launcher-sdk/src/addresses.test.ts
@@ -32,27 +32,32 @@ describe('getLauncherAddresses', () => {
     expect(addresses?.lbpStrategy).toBe(getAddress('0x298eA05D0356B2Ae5cCAa3169E471783ee9EA000'))
   })
 
-  it('keeps the live shared LiquidityLauncher CREATE2 address on every chain except Robinhood', () => {
+  it('keeps the live shared LiquidityLauncher CREATE2 address on every chain except Robinhood and Arc', () => {
     const sharedLauncher = getAddress('0x00004c4ccc709Ef590F7C81102C0689F0263D4e9')
     for (const chainId of Object.values(SupportedChainId).filter((v): v is number => typeof v === 'number')) {
-      if (chainId === SupportedChainId.ROBINHOOD) continue
+      if (chainId === SupportedChainId.ROBINHOOD || chainId === SupportedChainId.ARC) continue
       expect(getLauncherAddresses(chainId)?.liquidityLauncher).toBe(sharedLauncher)
     }
   })
 
-  it('scopes the 2026-08-05 full-redeploy launcher to Robinhood (4663) in both registries', () => {
+  it('scopes the redeployed launcher to Robinhood (4663) and Arc (5042) in both registries', () => {
     const redeployLauncher = getAddress('0x0000FffFBE8efE702c8703aE3477FF5dE3d319C0')
-    expect(getLauncherAddresses(SupportedChainId.ROBINHOOD)?.liquidityLauncher).toBe(redeployLauncher)
-    expect(getInstantLaunchContracts(SupportedChainId.ROBINHOOD)?.liquidityLauncher).toBe(redeployLauncher)
+    for (const chainId of [SupportedChainId.ROBINHOOD, SupportedChainId.ARC]) {
+      expect(getLauncherAddresses(chainId)?.liquidityLauncher).toBe(redeployLauncher)
+      expect(getInstantLaunchContracts(chainId)?.liquidityLauncher).toBe(redeployLauncher)
+    }
   })
 
   it('returns undefined for an unsupported chain', () => {
     expect(getLauncherAddresses(999999)).toBeUndefined()
   })
 
-  it('carries the UniversalRouterStrategy only where it is deployed (4663 so far)', () => {
+  it('carries the UniversalRouterStrategy only where it is deployed (4663 and 5042 so far)', () => {
     expect(getLauncherAddresses(SupportedChainId.ROBINHOOD)?.universalRouterStrategy).toBe(
       getAddress('0x1242c9439d589cAE85E121B1f79f2aF51e91DCEE')
+    )
+    expect(getLauncherAddresses(SupportedChainId.ARC)?.universalRouterStrategy).toBe(
+      getAddress('0x0A122717bc36E3C7A7958128a5C789E0b070b3Ae')
     )
     expect(getLauncherAddresses(SupportedChainId.MAINNET)?.universalRouterStrategy).toBeUndefined()
   })
@@ -287,6 +292,69 @@ describe('Instant Launch deployment registry', () => {
       expect(launcherEntry).toBeDefined()
       expect(INSTANT_LAUNCH_CONTRACTS[chainId]!.liquidityLauncher).toBe(launcherEntry!.liquidityLauncher)
     }
+  })
+})
+
+describe('Arc (5042) deployment', () => {
+  // Independent literals from the chain-5042 deploy log, verified on-chain (2026-09-01): variant
+  // identity via beneficiaryVault() (fees-on = the Arc vault, fees-off = address(0)), splitter
+  // wiring via feeSplitter() + getSplits(), pool shape via TICK_SPACING/initialTick/MIN_LAUNCH_TICK
+  // getters, and the ccaFactory via LBPStrategy.initializerFactory().
+  const ARC_FEES_ON_STRATEGY = getAddress('0x26e7803154f31540185f13c7540B0148F8F0De4b')
+  const ARC_FEES_OFF_STRATEGY = getAddress('0xe510927f92c1E66a9E655E1D73F4367125E04EFF')
+  const ARC_FEES_ON_SPLITTER = getAddress('0xC2F1D91599d7CB04E6BB156AB3D10972cC2da607')
+  const ARC_FEES_OFF_SPLITTER = getAddress('0xCDDC6103dD64dd05Cf634166326a21Be06B3165A')
+
+  it('carries the Arc launcher stack', () => {
+    const addresses = getLauncherAddresses(SupportedChainId.ARC)!
+    expect(addresses.lbpStrategy).toBe(getAddress('0xe9f36bcc222a6d2e459529D787f8c060d543A000'))
+    // Arc keeps the shared TokenSplitter, unlike Robinhood's full-redeploy one.
+    expect(addresses.tokenSplitter).toBe(getAddress('0x8B7DCeb5639DB986FCf86606C74e6300C40FE3cd'))
+    expect(addresses.positionManager).toBe(getAddress('0x6049c9a0e26405C0985f9E3685C87d0aE917f82B'))
+  })
+
+  it('supports pre-existing-token launches only (no token factory on 5042)', () => {
+    expect(selectTokenFactory(getLauncherAddresses(SupportedChainId.ARC)!)).toBeUndefined()
+  })
+
+  it('registers one Instant Launch generation with the redeploy pool shape', () => {
+    const deployments = getInstantLaunchDeployments(SupportedChainId.ARC)
+    expect(deployments).toHaveLength(2)
+    const [on, off] = deployments
+    expect(on!.strategy).toBe(ARC_FEES_ON_STRATEGY)
+    expect(on!.feeSplitter).toBe(ARC_FEES_ON_SPLITTER)
+    expect(on!.creatorFeesEnabled).toBe(true)
+    expect(on!.creatorFeeNativeBps).toBe(4000)
+    expect(off!.strategy).toBe(ARC_FEES_OFF_STRATEGY)
+    expect(off!.feeSplitter).toBe(ARC_FEES_OFF_SPLITTER)
+    expect(off!.creatorFeesEnabled).toBe(false)
+    for (const variant of [on!, off!]) {
+      expect(variant.tickSpacing).toBe(25)
+      expect(variant.initialTick).toBe(198050)
+      expect(variant.minLaunchTick).toBe(-160100)
+    }
+    expect(getInstantLaunchStrategy(SupportedChainId.ARC, { creatorFeesEnabled: true })?.strategy).toBe(
+      ARC_FEES_ON_STRATEGY
+    )
+    expect(getInstantLaunchStrategy(SupportedChainId.ARC, { creatorFeesEnabled: false })?.strategy).toBe(
+      ARC_FEES_OFF_STRATEGY
+    )
+  })
+
+  it('carries the Arc singletons (vault, compounding recipient)', () => {
+    const contracts = getInstantLaunchContracts(SupportedChainId.ARC)
+    expect(contracts?.beneficiaryVault).toBe(getAddress('0x3892aB3Dcf62785Ee3077ea008486c3a6bCf51Af'))
+    expect(contracts?.compoundingClaimRecipient).toBe(getAddress('0xBE5A26C5E7ABC4f049971e18214301931e23D1Db'))
+  })
+
+  it('resolves the Arc position recipients per variant', () => {
+    expect(getCreatorFeesPositionRecipient(SupportedChainId.ARC)).toBe(ARC_FEES_ON_SPLITTER)
+    expect(getAutocompoundPositionRecipient(SupportedChainId.ARC)).toBe(ARC_FEES_OFF_SPLITTER)
+    expect(isCreatorFeesPositionRecipient(SupportedChainId.ARC, ARC_FEES_ON_SPLITTER)).toBe(true)
+    expect(isCreatorFeesPositionRecipient(SupportedChainId.ARC, ARC_FEES_OFF_SPLITTER)).toBe(false)
+    expect(isAutocompoundPositionRecipient(SupportedChainId.ARC, ARC_FEES_OFF_SPLITTER)).toBe(true)
+    // Chain-scoped: the Robinhood splitters never classify on Arc.
+    expect(isCreatorFeesPositionRecipient(SupportedChainId.ARC, FEES_ON_SPLITTER_20260805)).toBe(false)
   })
 })
 

--- a/sdks/liquidity-launcher-sdk/src/addresses.ts
+++ b/sdks/liquidity-launcher-sdk/src/addresses.ts
@@ -42,22 +42,25 @@ const PERMIT2 = getAddress('0x000000000022D473030F116dDEE9F6B43aC78BA3')
 
 // Deployed at the same CREATE2 address on every supported chain.
 const LIQUIDITY_LAUNCHER = getAddress('0x00004c4ccc709Ef590F7C81102C0689F0263D4e9')
-// Liquidity-launcher deploy on chain 4663 only. The #223/#227 redeploy changed the launcher's
-// bytecode so the original mined vanity salt no longer resolves to LIQUIDITY_LAUNCHER. Scoped to
-// Robinhood because 4663 is the only chain it exists on; once this launcher is deployed on every
-// chain, this constant collapses back into LIQUIDITY_LAUNCHER.
+// The #223/#227 redeployed launcher: the redeploy changed the launcher's bytecode so the original
+// mined vanity salt no longer resolves to LIQUIDITY_LAUNCHER. Deployed on Robinhood (4663, the
+// 2026-08-05 full redeploy) and Arc (5042); once it is deployed on every chain, this constant
+// collapses back into LIQUIDITY_LAUNCHER.
 //
 // 2026-08-05 full redeploy: the re-mined launcher, superseding the v3.1.1 interim launcher
 // `0x7A6C474b…` (which itself superseded the never-launched v3.1.0 dev launcher `0xe050309b…`).
 // Unlike the v3.1.0 removal, the v3.1.1 generation has indexed launches, so its strategy pair
 // stays registered in {@link INSTANT_LAUNCH_DEPLOYMENTS} below — only the "current" pointers move.
-const LIQUIDITY_LAUNCHER_ROBINHOOD = getAddress('0x0000FffFBE8efE702c8703aE3477FF5dE3d319C0')
-// UniversalRouterStrategy, pinned to LIQUIDITY_LAUNCHER_ROBINHOOD as a constructor immutable.
+const LIQUIDITY_LAUNCHER_REDEPLOYED = getAddress('0x0000FffFBE8efE702c8703aE3477FF5dE3d319C0')
+// UniversalRouterStrategy, pinned to LIQUIDITY_LAUNCHER_REDEPLOYED as a constructor immutable.
 // Deployed via CREATE2 at salt 0 through the canonical deployer (liquidity-launcher#227
-// `DeployUniversalRouterStrategy.s.sol`), so it is chain-independent too — but it is only deployed
-// on 4663 so far, hence the per-chain optional field. 2026-08-05 full redeploy; supersedes the
-// v3.1.1 `0x4962907c…` (and the v3.1.0 `0xB7fF4d94…` before it).
+// `DeployUniversalRouterStrategy.s.sol`) — but it is only deployed per-chain so far, hence the
+// per-chain optional field. 2026-08-05 full redeploy; supersedes the v3.1.1 `0x4962907c…` (and the
+// v3.1.0 `0xB7fF4d94…` before it).
 const UNIVERSAL_ROUTER_STRATEGY_ROBINHOOD = getAddress('0x1242c9439d589cAE85E121B1f79f2aF51e91DCEE')
+// Arc deploy of the UniversalRouterStrategy (a different address than Robinhood's despite the same
+// launcher immutable — read back from the 5042 deploy; `launcher()` verified on-chain).
+const UNIVERSAL_ROUTER_STRATEGY_ARC = getAddress('0x0A122717bc36E3C7A7958128a5C789E0b070b3Ae')
 // Current CCA factory: the 2026-07-09 redeploy built against blocknumberish v1.1.0, which translates
 // block.number on every chain that needs it (e.g. Arbitrum One and Robinhood/4663 — the earlier
 // factory only handled Arbitrum, so on other translated chains it derived auction block ranges
@@ -71,7 +74,7 @@ const CCA_FACTORY = getAddress('0x000000001F26a0044BaA66024e7b6599c61963F8')
 const CCA_FACTORY_LEGACY = getAddress('0x00cCa200BF124dBfA848937c553864f4B4CE0632')
 const TOKEN_SPLITTER = getAddress('0x8B7DCeb5639DB986FCf86606C74e6300C40FE3cd')
 // 2026-08-05 full-redeploy TokenSplitter, chain 4663 only — the rest of the chains keep the shared
-// TOKEN_SPLITTER above. Same collapse caveat as LIQUIDITY_LAUNCHER_ROBINHOOD.
+// TOKEN_SPLITTER above. Same collapse caveat as LIQUIDITY_LAUNCHER_REDEPLOYED.
 const TOKEN_SPLITTER_ROBINHOOD = getAddress('0x4F5E3FBb9745358A92Da5674305FAb8D2B8a73cE')
 
 // Token factories, split by token standard. The uERC20 factory shares a CREATE2 address across the
@@ -87,6 +90,7 @@ const POSITION_MANAGER_ARBITRUM = getAddress('0xd88F38F930b7952f2DB2432Cb002E7ab
 const POSITION_MANAGER_AVALANCHE = getAddress('0xB74b1F14d2754AcfcbBe1a221023a5cf50Ab8ACD')
 const POSITION_MANAGER_XLAYER = getAddress('0xcF1EAFC6928dC385A342E7C6491d371d2871458b')
 const POSITION_MANAGER_ROBINHOOD = getAddress('0x58daec3116aae6D93017bAAea7749052E8a04fA7')
+const POSITION_MANAGER_ARC = getAddress('0x6049c9a0e26405C0985f9E3685C87d0aE917f82B')
 const POSITION_MANAGER_SEPOLIA = getAddress('0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4')
 const POSITION_MANAGER_BASE_SEPOLIA = getAddress('0x4B2C77d209D3405F41a037Ec6c77F7F5b8e2ca80')
 
@@ -148,7 +152,7 @@ export const LAUNCHER_ADDRESSES: Partial<Record<number, LauncherAddresses>> = {
     positionManager: POSITION_MANAGER_XLAYER,
   },
   [SupportedChainId.ROBINHOOD]: {
-    liquidityLauncher: LIQUIDITY_LAUNCHER_ROBINHOOD,
+    liquidityLauncher: LIQUIDITY_LAUNCHER_REDEPLOYED,
     lbpStrategy: getAddress('0x05d552391067389EE44fec3924157ed33F976000'),
     tokenSplitter: TOKEN_SPLITTER_ROBINHOOD,
     ccaFactory: CCA_FACTORY,
@@ -156,6 +160,19 @@ export const LAUNCHER_ADDRESSES: Partial<Record<number, LauncherAddresses>> = {
     universalRouterStrategy: UNIVERSAL_ROUTER_STRATEGY_ROBINHOOD,
     uerc20Factory: UERC20_FACTORY,
     positionManager: POSITION_MANAGER_ROBINHOOD,
+  },
+  [SupportedChainId.ARC]: {
+    liquidityLauncher: LIQUIDITY_LAUNCHER_REDEPLOYED,
+    lbpStrategy: getAddress('0xe9f36bcc222a6d2e459529D787f8c060d543A000'),
+    // Arc keeps the shared TokenSplitter (verified deployed on 5042), unlike Robinhood's
+    // full-redeploy splitter. ccaFactory verified on-chain via LBPStrategy.initializerFactory().
+    tokenSplitter: TOKEN_SPLITTER,
+    ccaFactory: CCA_FACTORY,
+    permit2: PERMIT2,
+    universalRouterStrategy: UNIVERSAL_ROUTER_STRATEGY_ARC,
+    // No token factory on 5042 (neither the uERC20 nor the super-uERC20 CREATE2 address has code),
+    // so Arc supports launches with pre-existing tokens only.
+    positionManager: POSITION_MANAGER_ARC,
   },
   [SupportedChainId.SEPOLIA]: {
     liquidityLauncher: LIQUIDITY_LAUNCHER,
@@ -307,7 +324,7 @@ const INSTANT_LAUNCH_STRATEGY_FEES_OFF_ROBINHOOD_3E05DA8 = getAddress('0x16b63f1
 // v3.1.1, re-pinned to the interim v3.1.1 launcher `0x7A6C474b…`.
 const INSTANT_LAUNCH_STRATEGY_FEES_ON_ROBINHOOD_V311 = getAddress('0x3f556B542105D5EFBBefe7C766a4919C76B960Fb')
 const INSTANT_LAUNCH_STRATEGY_FEES_OFF_ROBINHOOD_V311 = getAddress('0x36bdB859518C89F764337cd5C24762d2Aa650f3C')
-// 2026-08-05 full redeploy, re-pinned to LIQUIDITY_LAUNCHER_ROBINHOOD.
+// 2026-08-05 full redeploy, re-pinned to LIQUIDITY_LAUNCHER_REDEPLOYED.
 const INSTANT_LAUNCH_STRATEGY_FEES_ON_ROBINHOOD_20260805 = getAddress('0x23f8209572b4a1C2AD88A42749E830791Fb027f1')
 const INSTANT_LAUNCH_STRATEGY_FEES_OFF_ROBINHOOD_20260805 = getAddress('0xAD44D55E7f8337C3cE113fBb591486E85be104b2')
 // FeeSplitters. The fees-on side got a fresh splitter in v3.1.1 (it points at the v3.1.1 beneficiary
@@ -329,6 +346,20 @@ const UERC20_BENEFICIARY_VAULT_ROBINHOOD = getAddress('0xd35E9CA72F64C7F93BE30fa
 // CompoundingClaimRecipient. 2026-08-05 full redeploy; supersedes `0x666DA634…`, which remains the
 // autocompound claim surface of the older generations' splitters.
 const COMPOUNDING_CLAIM_RECIPIENT_ROBINHOOD = getAddress('0xf9526Dd3361fe0ba6b7a99533ed471D3E808E99a')
+
+// Arc (5042) Instant Launch stack — a single generation so far, deployed alongside the chain's
+// launcher stack. Same pool shape as the Robinhood 2026-08-05 full redeploy (TICK_SPACING 25,
+// initialTick 198,050, MIN_LAUNCH_TICK -160,100 — read back from the deployed strategies' getters)
+// and the same split table (fees-on: 40% native to the vault, 60% native + 100% token
+// autocompounding; fees-off: 100% of both sides autocompounding — read back via getSplits()).
+// Variant identification verified on-chain: the fees-on strategy's beneficiaryVault() is the Arc
+// vault below, the fees-off strategy's is address(0).
+const INSTANT_LAUNCH_STRATEGY_FEES_ON_ARC = getAddress('0x26e7803154f31540185f13c7540B0148F8F0De4b')
+const INSTANT_LAUNCH_STRATEGY_FEES_OFF_ARC = getAddress('0xe510927f92c1E66a9E655E1D73F4367125E04EFF')
+const INSTANT_LAUNCH_FEE_SPLITTER_FEES_ON_ARC = getAddress('0xC2F1D91599d7CB04E6BB156AB3D10972cC2da607')
+const INSTANT_LAUNCH_FEE_SPLITTER_FEES_OFF_ARC = getAddress('0xCDDC6103dD64dd05Cf634166326a21Be06B3165A')
+const UERC20_BENEFICIARY_VAULT_ARC = getAddress('0x3892aB3Dcf62785Ee3077ea008486c3a6bCf51Af')
+const COMPOUNDING_CLAIM_RECIPIENT_ARC = getAddress('0xBE5A26C5E7ABC4f049971e18214301931e23D1Db')
 
 /** FeeSplitter splits are expressed in basis points summing to this denominator per currency side. */
 export const FEE_SPLIT_BPS_DENOMINATOR = 10_000
@@ -541,14 +572,45 @@ export const INSTANT_LAUNCH_DEPLOYMENTS: readonly InstantLaunchDeployment[] = [
     description:
       'Instant Launch without creator fees (2026-08-05, full 4663 stack redeploy, current): recompiled with the new pool shape (TICK_SPACING 25, initialTick 198,050, MIN_LAUNCH_TICK -160,100) and pinned to the final re-mined LiquidityLauncher; zero beneficiary vault; new FeeSplitter forwarding 100% of both fee sides to the new CompoundingClaimRecipient',
   },
+  {
+    chainId: SupportedChainId.ARC,
+    strategy: INSTANT_LAUNCH_STRATEGY_FEES_ON_ARC,
+    feeSplitter: INSTANT_LAUNCH_FEE_SPLITTER_FEES_ON_ARC,
+    creatorFeesEnabled: true,
+    creatorFeeNativeBps: 4000,
+    creatorFeeTokenBps: 0,
+    tickSpacing: 25,
+    initialTick: 198050,
+    minLaunchTick: -160100,
+    description:
+      'Instant Launch with creator fees (Arc/5042 initial stack, current): same pool shape as the 2026-08-05 Robinhood redeploy, pinned to the re-mined LiquidityLauncher; FeeSplitter forwarding 40% of native fees to the Arc UERC20BeneficiaryVault, 60% native + 100% token to the Arc CompoundingClaimRecipient',
+  },
+  {
+    chainId: SupportedChainId.ARC,
+    strategy: INSTANT_LAUNCH_STRATEGY_FEES_OFF_ARC,
+    feeSplitter: INSTANT_LAUNCH_FEE_SPLITTER_FEES_OFF_ARC,
+    creatorFeesEnabled: false,
+    creatorFeeNativeBps: 0,
+    creatorFeeTokenBps: 0,
+    tickSpacing: 25,
+    initialTick: 198050,
+    minLaunchTick: -160100,
+    description:
+      'Instant Launch without creator fees (Arc/5042 initial stack, current): same pool shape as the 2026-08-05 Robinhood redeploy, pinned to the re-mined LiquidityLauncher; zero beneficiary vault; FeeSplitter forwarding 100% of both fee sides to the Arc CompoundingClaimRecipient',
+  },
 ]
 
 /** The per-chain Instant Launch singleton contracts, keyed by numeric chain id. */
 export const INSTANT_LAUNCH_CONTRACTS: Partial<Record<number, InstantLaunchChainContracts>> = {
   [SupportedChainId.ROBINHOOD]: {
-    liquidityLauncher: LIQUIDITY_LAUNCHER_ROBINHOOD,
+    liquidityLauncher: LIQUIDITY_LAUNCHER_REDEPLOYED,
     beneficiaryVault: UERC20_BENEFICIARY_VAULT_ROBINHOOD,
     compoundingClaimRecipient: COMPOUNDING_CLAIM_RECIPIENT_ROBINHOOD,
+  },
+  [SupportedChainId.ARC]: {
+    liquidityLauncher: LIQUIDITY_LAUNCHER_REDEPLOYED,
+    beneficiaryVault: UERC20_BENEFICIARY_VAULT_ARC,
+    compoundingClaimRecipient: COMPOUNDING_CLAIM_RECIPIENT_ARC,
   },
 }
 

--- a/sdks/liquidity-launcher-sdk/src/chains.ts
+++ b/sdks/liquidity-launcher-sdk/src/chains.ts
@@ -11,6 +11,7 @@ export enum SupportedChainId {
   AVALANCHE = 43114,
   XLAYER = 196,
   ROBINHOOD = 4663,
+  ARC = 5042,
   SEPOLIA = 11155111,
   BASE_SEPOLIA = 84532,
 }


### PR DESCRIPTION
## PR Scope

`feat(liquidity-launcher-sdk)` — minor version bump (→ 1.12.0 when the changesets "Version Packages" PR lands).

## Description

**Before**: the SDK has no chain-5042 (Arc) entries — `getLauncherAddresses(5042)`, `getInstantLaunchDeployments(5042)` and `getInstantLaunchContracts(5042)` all resolve to nothing, so neither transaction builders nor indexers can target or classify the Arc deployment.

**After**: the Arc launcher stack and its Instant Launch generation are registered, with every address verified on-chain before registering (2026-09-01, via `eth_getCode` and the contracts' own getters).

### How

- `sdks/liquidity-launcher-sdk/src/chains.ts`: `SupportedChainId.ARC = 5042`.
- `sdks/liquidity-launcher-sdk/src/addresses.ts`
  - `LAUNCHER_ADDRESSES[5042]`: launcher `0x0000FffFBE8efE702c8703aE3477FF5dE3d319C0`, LBPStrategy `0xe9f36bcc222a6d2e459529D787f8c060d543A000`, TokenSplitter `0x8B7DCeb5639DB986FCf86606C74e6300C40FE3cd`, CCA factory `0x000000001F26a0044BaA66024e7b6599c61963F8` (read back from `LBPStrategy.initializerFactory()`), UniversalRouterStrategy `0x0A122717bc36E3C7A7958128a5C789E0b070b3Ae` (`launcher()` verified), PositionManager `0x6049c9a0e26405C0985f9E3685C87d0aE917f82B` (sdk-core `v4PositionManagerAddress`).
  - `INSTANT_LAUNCH_DEPLOYMENTS`: one Arc generation appended — fees-on `0x26e7803154f31540185f13c7540B0148F8F0De4b` + FeeSplitter `0xC2F1D91599d7CB04E6BB156AB3D10972cC2da607`, fees-off `0xe510927f92c1E66a9E655E1D73F4367125E04EFF` + FeeSplitter `0xCDDC6103dD64dd05Cf634166326a21Be06B3165A`. Variant identity read on-chain: `beneficiaryVault()` returns the Arc vault on the fees-on strategy and `address(0)` on the fees-off one; `getSplits()` confirms the split tables (fees-on: 40% native → vault, 60% native + 100% token → compounding; fees-off: 100%/100% → compounding). Pool shape read from the strategies' getters: `TICK_SPACING` 25, `initialTick` 198,050, `MIN_LAUNCH_TICK` −160,100.
  - `INSTANT_LAUNCH_CONTRACTS[5042]`: singletons — UERC20BeneficiaryVault `0x3892aB3Dcf62785Ee3077ea008486c3a6bCf51Af`, CompoundingClaimRecipient `0xBE5A26C5E7ABC4f049971e18214301931e23D1Db`.
  - Constant housekeeping: the launcher constant is now used by more than one chain, so it is renamed `LIQUIDITY_LAUNCHER_REDEPLOYED` (value unchanged); prior entries are byte-for-byte unchanged.
- Tests (`addresses.test.ts`): a new `Arc (5042) deployment` block pins the launcher stack, the instant-launch generation (variants, split bps, pool shape), the singletons, and per-variant position recipients — every address asserted as an independent string literal, not derived from the registry. The chain-iteration assertions gained the 5042 case.
- `.changeset/arc-liquidity-launcher-addresses.md`: `minor` bump. `package.json` version untouched (changesets handles it).

**Intentionally unchanged / not included**: no token factory is registered for 5042 — neither the uERC20 nor the super-uERC20 CREATE2 address has code there, so `selectTokenFactory` / `getInstantLaunchAddresses` / `isInstantLaunchSupported` deliberately resolve to undefined/false (pre-existing-token launches only) until a factory deploy lands. The InitializerHook (`0x95E67F3F…`) is not tracked by this SDK. No ABI, type, or function-signature changes.

## How Has This Been Tested?

- `bun test` (package): 238 pass / 0 fail
- `turbo run build --filter=@uniswap/liquidity-launcher-sdk...` (cjs/esm/types): clean
- `bun run lint`: clean

## Are there any breaking changes?

No — address-registry additions only; no API surface changes.

## (Optional) Feedback Focus

- The instant-launch `creatorFeeNativeBps: 4000` and pool-shape values were read back from the deployed contracts' getters rather than a deploy manifest — please confirm they match the intended 5042 configuration.
- `deployedAtBlock` is left unset on the new registry entries (the deploy log carried no block numbers); happy to add them if you have the deploy blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
