### PR TITLE
fix(uniswapx-sdk): recoverCosigner uses raw ecrecover, resolve() honors cosigned target-block override

### DIFF
--- a/sdks/uniswapx-sdk/src/order/PriorityOrder.test.ts
+++ b/sdks/uniswapx-sdk/src/order/PriorityOrder.test.ts
@@ -71,20 +71,62 @@ describe("PriorityOrder", () => {
   });
 
   describe("resolve", () => {
-    it("throws when resolving if current block < auctionTargetBlock", () => {
+    it("throws when resolving before auctionStartBlock and no cosigner is set (no override applies)", () => {
+      // Default fixture has cosigner = AddressZero, so per PriorityOrderReactor.sol
+      // the cosigned auctionTargetBlock never overrides auctionStartBlock, and the
+      // only relevant check is against the signed auctionStartBlock itself.
       let order = new CosignedPriorityOrder(getFullOrderInfo({}), 1);
       expect(() =>
         order.resolve({
           priorityFee: BigNumber.from(1),
           currentBlock: BLOCK.sub(10),
         })
-      ).toThrowError(new OrderNotFillable("Target block in the future"));
+      ).toThrowError(new OrderNotFillable("Start block in the future"));
 
       order = new CosignedPriorityOrder(
         getFullOrderInfo({
           cosignerData: {
             auctionTargetBlock: BigNumber.from(0),
           },
+        }),
+        1
+      );
+
+      expect(() =>
+        order.resolve({
+          priorityFee: BigNumber.from(1),
+          currentBlock: BLOCK.sub(1),
+        })
+      ).toThrowError(new OrderNotFillable("Start block in the future"));
+    });
+
+    it("applies the cosigned auctionTargetBlock override when a cosigner is set and target < start (matches PriorityOrderReactor.sol)", () => {
+      // cosigner set, target (BLOCK - 30) < start (BLOCK), current (BLOCK - 20) is
+      // between target and start: the reactor overrides auctionStartBlock with the
+      // cosigned target and fills; the un-overridden SDK used to throw here.
+      const order = new CosignedPriorityOrder(
+        getFullOrderInfo({
+          cosigner: "0x0000000000000000000000000000000000000001",
+          cosignerData: { auctionTargetBlock: BLOCK.sub(30) },
+        }),
+        1
+      );
+
+      const resolved = order.resolve({
+        priorityFee: BigNumber.from(1),
+        currentBlock: BLOCK.sub(20),
+      });
+      expect(resolved.input.token).toEqual(order.info.input.token);
+    });
+
+    it("does not apply the override when the cosigned target is not before auctionStartBlock", () => {
+      // cosigner set, but target (BLOCK + 50) is NOT before start (BLOCK), so no
+      // override applies per the reactor; current (BLOCK - 1) is before the
+      // (un-overridden) start, so it must still throw.
+      const order = new CosignedPriorityOrder(
+        getFullOrderInfo({
+          cosigner: "0x0000000000000000000000000000000000000001",
+          cosignerData: { auctionTargetBlock: BLOCK.add(50) },
         }),
         1
       );
@@ -109,6 +151,30 @@ describe("PriorityOrder", () => {
       expect(resolved.outputs[0].amount).toEqual(
         order.info.outputs[0].amount.add(1)
       );
+    });
+  });
+
+  describe("recoverCosigner", () => {
+    it("recovers the cosigner from a raw ecrecover-style signature (matches CosignerLib.sol)", async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const orderInfo = getFullOrderInfo({
+        cosigner: await wallet.getAddress(),
+      });
+      const order = new CosignedPriorityOrder(orderInfo, 1);
+      const fullOrderHash = order.cosignatureHash(orderInfo.cosignerData);
+
+      // Cosignatures are verified on-chain via raw `ecrecover` (CosignerLib.sol),
+      // not EIP-191 `personal_sign` — sign with signDigest to match the reactor.
+      const cosignature = ethers.utils.joinSignature(
+        wallet._signingKey().signDigest(fullOrderHash)
+      );
+
+      const signedOrder = new CosignedPriorityOrder(
+        { ...orderInfo, cosignature },
+        1
+      );
+
+      expect(signedOrder.recoverCosigner()).toEqual(await wallet.getAddress());
     });
   });
 });

--- a/sdks/uniswapx-sdk/src/order/PriorityOrder.ts
+++ b/sdks/uniswapx-sdk/src/order/PriorityOrder.ts
@@ -463,12 +463,17 @@ export class CosignedPriorityOrder extends UnsignedPriorityOrder {
    */
   resolve(options: PriorityOrderResolutionOptions): ResolvedUniswapXOrder {
     if (options.currentBlock) {
-      if (
-        this.info.cosignerData.auctionTargetBlock.gt(0) &&
-        options.currentBlock.lt(this.info.cosignerData.auctionTargetBlock)
-      ) {
-        throw new OrderNotFillable("Target block in the future");
-      } else if (options.currentBlock.lt(this.info.auctionStartBlock)) {
+      // PriorityOrderReactor.sol#_validateOrder: the signed auctionStartBlock is
+      // replaced with the cosigned auctionTargetBlock only when a cosigner is set,
+      // the current block precedes the signed start, and the target precedes it too.
+      const auctionStartBlock =
+        this.info.cosigner !== ethers.constants.AddressZero &&
+        options.currentBlock.lt(this.info.auctionStartBlock) &&
+        this.info.cosignerData.auctionTargetBlock.lt(this.info.auctionStartBlock)
+          ? this.info.cosignerData.auctionTargetBlock
+          : this.info.auctionStartBlock;
+
+      if (options.currentBlock.lt(auctionStartBlock)) {
         throw new OrderNotFillable("Start block in the future");
       }
     }
@@ -530,7 +535,7 @@ export class CosignedPriorityOrder extends UnsignedPriorityOrder {
    *  @returns The address which co-signed the order
    */
   recoverCosigner(): string {
-    return ethers.utils.verifyMessage(
+    return ethers.utils.recoverAddress(
       this.cosignatureHash(this.info.cosignerData),
       this.info.cosignature
     );

--- a/sdks/uniswapx-sdk/src/order/V2DutchOrder.test.ts
+++ b/sdks/uniswapx-sdk/src/order/V2DutchOrder.test.ts
@@ -142,7 +142,11 @@ describe("V2DutchOrder", () => {
     });
     const order = new UnsignedV2DutchOrder(orderInfo, 1);
     const fullOrderHash = order.cosignatureHash(orderInfo.cosignerData);
-    const cosignature = await wallet.signMessage(fullOrderHash);
+    // Cosignatures are verified on-chain via raw `ecrecover` (CosignerLib.sol),
+    // not EIP-191 `personal_sign` — sign with signDigest to match the reactor.
+    const cosignature = ethers.utils.joinSignature(
+      wallet._signingKey().signDigest(fullOrderHash)
+    );
     const signedOrder = CosignedV2DutchOrder.fromUnsignedOrder(
       order,
       COSIGNER_DATA,

--- a/sdks/uniswapx-sdk/src/order/V2DutchOrder.ts
+++ b/sdks/uniswapx-sdk/src/order/V2DutchOrder.ts
@@ -535,7 +535,7 @@ export class CosignedV2DutchOrder extends UnsignedV2DutchOrder {
    *  @returns The address which co-signed the order
    */
   recoverCosigner(): string {
-    return ethers.utils.verifyMessage(
+    return ethers.utils.recoverAddress(
       this.cosignatureHash(this.info.cosignerData),
       this.info.cosignature
     );


### PR DESCRIPTION
Two independent SDK/reactor disagreements in `uniswapx-sdk`, both in the cosigning path.

## 1. `recoverCosigner()` used EIP-191 `personal_sign`, the reactor uses raw `ecrecover`

`V2DutchOrder.ts` and `PriorityOrder.ts` both did:
```ts
return ethers.utils.verifyMessage(this.cosignatureHash(this.info.cosignerData), this.info.cosignature);
```
`CosignerLib.sol` (fetched from `Uniswap/UniswapX`) verifies cosignatures with a raw, unprefixed digest:
```solidity
function verify(address cosigner, bytes32 data, bytes memory cosignature) internal pure {
    (bytes32 r, bytes32 s) = abi.decode(cosignature, (bytes32, bytes32));
    uint8 v = uint8(cosignature[64]);
    address signer = ecrecover(data, v, r, s);
    if (cosigner != signer || signer == address(0)) revert InvalidCosignature();
}
```
`verifyMessage` applies the `\x19Ethereum Signed Message:\n` prefix over the UTF-8 text of the hex digest; `ecrecover` operates on the raw 32-byte digest. These schemes can never agree for the same signature.

The correct sibling in the same package already had this right — `V3DutchOrder.recoverCosigner()` uses `ethers.utils.recoverAddress`. This PR brings V2DutchOrder and PriorityOrder in line with it (and with the reactor).

**The existing test was circular.** `V2DutchOrder.test.ts`'s cosigner test produced its test signature via `wallet.signMessage(fullOrderHash)` — the exact inverse of `verifyMessage` — so it was self-consistent with the bug, not validated against the reactor's real scheme. Fixed to sign with `signDigest`, matching how this repo's own integration tests (`V2DutchOrder.spec.ts`, `PriorityOrderValidator.spec.ts`) already sign cosignatures for real reactor execution. `CosignedPriorityOrder.recoverCosigner()` had **no test at all**; added one.

**Real repro** (verified locally before touching code): signed a real digest with `wallet._signingKey().signDigest(...)` (the raw ecrecover-compatible scheme), confirmed `ethers.utils.recoverAddress` recovers the correct signer while the pre-fix `recoverCosigner()` (via `verifyMessage`) recovers a completely different address. Isolated the defect to the recovery scheme specifically — both `cosignatureHash()` implementations were independently re-derived from `PriorityOrderLib.sol`/`V2DutchOrderReactor.sol` and match.

**Honest scoping:** `recoverCosigner()` has no internal caller in this SDK — it's public API for downstream fillers/quoters. This is **not** a forgery path; an attacker still needs the real cosigner's private key regardless of which recovery scheme is used. Which direction UniswapX's production cosigner service actually emits wasn't observed here — what's proven is that the SDK's `recoverCosigner()` cannot agree with what the reactor verifies, since the reactor is unambiguously raw `ecrecover`.

## 2. `PriorityOrder.resolve()` never applied the cosigned target-block override

`PriorityOrderReactor.sol#_validateOrder` overrides the signed `auctionStartBlock` with the cosigned `auctionTargetBlock` — but only when a cosigner is set, the current block precedes the signed start, and the target itself precedes the signed start:
```solidity
if (order.cosigner != address(0) && block.number < auctionStartBlock
        && order.cosignerData.auctionTargetBlock < auctionStartBlock) {
    CosignerLib.verify(...);
    auctionStartBlock = order.cosignerData.auctionTargetBlock;
}
if (block.number < auctionStartBlock) revert OrderNotFillable();
```
The SDK instead had two independent, unconditional branches — an early "target in the future" throw with no cosigner/target-vs-start awareness, and a separate "start in the future" throw that was never overridden. Net effect: the SDK threw `OrderNotFillable` on orders the reactor actually fills, throughout the entire window `[auctionTargetBlock, auctionStartBlock)` — exactly the window cosigning exists to open early.

Fixed `resolve()` to compute the same effective `auctionStartBlock` the reactor computes, then check fillability once against it — same condition, same order, same comparisons.

**Verified with an exhaustive sweep** (990 combinations: cosigner set/zero × start 98-102 × target 96-104 × current 95-105, comparing the old SDK logic against a faithful port of the reactor's `_validateOrder`) before touching code: **165 disagreements, all one-directional** (SDK refuses, reactor fills), **all requiring a non-zero cosigner** — confirming the SDK was correct whenever no cosigner is set, which is exactly why every existing fixture (which all default to `cosigner: AddressZero`) never caught this.

**The existing "control" test was itself relying on the bug.** Its default fixture has `cosigner: AddressZero`, so per the reactor the override can never apply — yet the old code still threw the (Solidity-nonexistent) message *"Target block in the future"* purely from its own unconditional first branch, unrelated to any real revert reason. Fixed that test's expectation to the corrected single message, and added two new tests: one exercising the override actually applying (cosigner set, target < start, current inside the window — now fills instead of throwing), one exercising it correctly *not* applying (cosigner set but target ≥ start — still throws).

**Honest scoping:** all 165 disagreements are SDK-too-strict / reactor-more-permissive — there is no over-permissive direction, so this is a missed-fills bug for SDK-driven fillers during the cosigned early window, not a fund-safety issue.

**Deliberately left unfixed:** `CosignedPriorityOrder.blockOverrides` also unconditionally reports the cosigned target block regardless of whether the reactor would apply the override. Unlike `resolve()`, this getter takes no `currentBlock` parameter, so it structurally cannot replicate the reactor's conditional logic without an API change — out of scope for this PR.

## receipts

```
$ bun test src/
 353 pass
 0 fail
 1 snapshots, 523 expect() calls
Ran 353 tests across 24 files.   (was 350/0/24 before this change — +3 new tests)

$ bunx tsc -p tsconfig.cjs.json --noEmit
(clean, no output)
```

Genuine red-before/green-after confirmed by stashing just the source fixes (`PriorityOrder.ts`, `V2DutchOrder.ts`) with the new/modified tests still in place — all 4 affected tests fail with the exact predicted symptoms, restoring the source fixes brings them all back to green.

## risk

Low — both fixes replace one `ethers` call / one conditional with the exact pattern already proven correct elsewhere in the same package (V3DutchOrder's `recoverCosigner`, the reactor's own override logic). No change to digest computation, only to signature verification and fillability-check logic.
