### PR TITLE
fix(router-sdk): encodeMixedRouteToPath resolves the wrong pool token at a native/wrapped boundary

### DIFF
--- a/.changeset/fix-encode-mixed-route-fallthrough.md
+++ b/.changeset/fix-encode-mixed-route-fallthrough.md
@@ -1,0 +1,5 @@
+---
+'@uniswap/router-sdk': patch
+---
+
+Fix `encodeMixedRouteToPath` resolving the wrong side of a pool at a native/wrapped currency boundary. Both branches now read each hop's currency directly from the route's already-resolved `path` instead of re-deriving it via `pool.token0.equals(currencyIn) ? pool.token1 : pool.token0`, which silently fell through to `pool.token0` whenever neither pool token matched by exact reference (same root cause fixed for `midPrice` in #706).

--- a/sdks/router-sdk/src/utils/encodeMixedRouteToPath.test.ts
+++ b/sdks/router-sdk/src/utils/encodeMixedRouteToPath.test.ts
@@ -13,6 +13,11 @@ describe('#encodeMixedRouteToPath', () => {
   const token2 = new Token(1, '0x0000000000000000000000000000000000000003', 18, 't2', 'token2')
 
   const weth = WETH9[1]
+  // sorts ABOVE weth's address (0xC02a...) -- unlike token0/1/2 above, which all sort below it.
+  // The pre-fix fallthrough-to-pool.token0 logic happened to be correct whenever the non-weth
+  // token sorted below weth, and wrong whenever it sorted above -- these fixtures exercise the
+  // side that was silently broken.
+  const tokenHigh = new Token(1, '0xdAC17F958D2ee523a2206206994597C13D831ec7', 6, 'high', 'tokenHigh')
 
   const pool_V3_0_1_medium = new V3Pool(token0, token1, FeeAmount.MEDIUM, encodeSqrtRatioX96(1, 1), 0, 0, [])
   const pool_V3_1_2_low = new V3Pool(token1, token2, FeeAmount.LOW, encodeSqrtRatioX96(1, 1), 0, 0, [])
@@ -222,6 +227,42 @@ describe('#encodeMixedRouteToPath', () => {
       // 0x0000000000000000000000000000000000000000
       // // last path address - v4 pool, token0
       // 0x0000000000000000000000000000000000000001
+    })
+  })
+
+  describe('native/wrapped boundary fallthrough (regression)', () => {
+    // Before the fix, the v4 branch re-derived each hop's output token via
+    // `currencyIn.equals(pool.token0) ? pool.token1 : pool.token0`, which falls through to
+    // `pool.token0` whenever neither side matches by exact reference -- exactly what happens at
+    // a native/wrapped boundary where the constructor resolves the hop via wrapped-equality
+    // rather than `.equals()`. Whether the fallthrough happened to be correct depended entirely
+    // on whether the non-weth token sorted above or below weth's address -- these fixtures use
+    // `tokenHigh`, which sorts above, to exercise the side that was silently broken.
+    const pool_V4_token0_eth = new V4Pool(token0, ETHER, FeeAmount.MEDIUM, 30, ADDRESS_ZERO, encodeSqrtRatioX96(1, 1), 0, 0, [])
+    const pool_V3_weth_high = new V3Pool(weth, tokenHigh, FeeAmount.MEDIUM, encodeSqrtRatioX96(1, 1), 0, 0, [])
+    const pair_weth_high = new Pair(
+      CurrencyAmount.fromRawAmount(weth, '100'),
+      CurrencyAmount.fromRawAmount(tokenHigh, '100')
+    )
+
+    it('v4 branch: resolves the correct terminal token across a native/wrapped boundary, not pool.token0', () => {
+      // token0 -[V4]-> ETH -[V3, weth<->tokenHigh]-> tokenHigh
+      const route = new MixedRouteSDK([pool_V4_token0_eth, pool_V3_weth_high], token0, tokenHigh)
+      const encoded = encodeMixedRouteToPath(route)
+
+      // cross-source invariant: the encoded path's terminal address must be route.pathOutput's
+      expect(encoded.toLowerCase().endsWith(route.pathOutput.wrapped.address.slice(2).toLowerCase())).toBe(true)
+      expect(encoded.toLowerCase()).not.toContain(weth.address.slice(2).toLowerCase())
+    })
+
+    it('legacy (non-v4) branch: resolves the correct terminal token for a native ETH input, not pool.token0', () => {
+      // ETH -[V2, weth<->tokenHigh]-> tokenHigh, no v4 pools so this hits the legacy branch
+      const route = new MixedRouteSDK([pair_weth_high], ETHER, tokenHigh)
+      const encoded = encodeMixedRouteToPath(route)
+
+      expect(encoded.toLowerCase().endsWith(route.pathOutput.wrapped.address.slice(2).toLowerCase())).toBe(true)
+      // pre-fix, this route encoded a WETH -> WETH self-loop
+      expect(encoded.toLowerCase().split(weth.address.slice(2).toLowerCase()).length - 1).toBe(1)
     })
   })
 })

--- a/sdks/router-sdk/src/utils/encodeMixedRouteToPath.ts
+++ b/sdks/router-sdk/src/utils/encodeMixedRouteToPath.ts
@@ -32,10 +32,17 @@ export function encodeMixedRouteToPath(
   if (containsV4Pool) {
     path = [route.pathInput.isNative ? ADDRESS_ZERO : route.pathInput.address]
     types = ['address']
-    let currencyIn = route.pathInput
 
-    for (const pool of route.pools) {
-      const currencyOut = currencyIn.equals(pool.token0) ? pool.token1 : pool.token0
+    // route.path[i + 1] is always pool i's own currency object -- the MixedRouteSDK constructor
+    // already resolves native/wrapped boundaries (including cases where neither the input nor
+    // output currency instance is literally `.equals()` to either of the pool's own token
+    // objects), so reading it directly is reliable. Re-deriving the output token here via
+    // `currencyIn.equals(pool.token0) ? pool.token1 : pool.token0` silently falls through to
+    // `pool.token0` whenever neither side matches by exact reference, which can pick the wrong
+    // side of the pool at a native/wrapped boundary (see fix(router-sdk) ROUTE-886 / #706, which
+    // fixed the identical fallthrough pattern in `MixedRouteSDK.midPrice` and `getOutputOfPools`).
+    for (const [i, pool] of route.pools.entries()) {
+      const currencyOut = route.path[i + 1]
 
       if (pool instanceof V4Pool) {
         // a tickSpacing of 0 indicates a "fake" v4 pool where the quote actually requires a wrap or unwrap
@@ -65,23 +72,30 @@ export function encodeMixedRouteToPath(
       } else {
         throw new Error(`Unsupported pool type ${JSON.stringify(pool)}`)
       }
-
-      currencyIn = currencyOut
     }
   } else {
     // TODO: ROUTE-276 - delete this else block
     // We introduced this else block as a safety measure to prevent non-v4 mixed routes from potentially regressing
     // We'd like to gain more confidence in the new implementation before removing this block
+
+    // Same fix as the v4 branch above: read each hop's currency straight from route.path (which
+    // the MixedRouteSDK constructor already resolves correctly, including native/wrapped
+    // boundaries) instead of re-deriving it here via `pool.token0.equals(inputToken) ? ... :
+    // pool.token0`, which silently falls through to `pool.token0` whenever `inputToken` doesn't
+    // exactly match either side of the pool (e.g. `route.input` is native ETH but the pool's
+    // tokens are the wrapped form). This also fixes seeding from `route.input`, which may be
+    // native, instead of `route.pathInput` (route.path[0]), which is already resolved to the
+    // form the first pool actually holds.
     const result = route.pools.reduce(
       (
-        { inputToken, path, types }: { inputToken: Currency; path: (string | number)[]; types: string[] },
+        { path, types }: { path: (string | number)[]; types: string[] },
         pool: TPool,
         index
-      ): { inputToken: Currency; path: (string | number)[]; types: string[] } => {
-        const outputToken: Currency = pool.token0.equals(inputToken) ? pool.token1 : pool.token0
+      ): { path: (string | number)[]; types: string[] } => {
+        const inputToken = route.path[index]
+        const outputToken = route.path[index + 1]
         if (index === 0) {
           return {
-            inputToken: outputToken,
             types: ['address', 'uint24', 'address'],
             path: [
               inputToken.wrapped.address,
@@ -91,7 +105,6 @@ export function encodeMixedRouteToPath(
           }
         } else {
           return {
-            inputToken: outputToken,
             types: [...types, 'uint24', 'address'],
             path: [
               ...path,
@@ -101,7 +114,7 @@ export function encodeMixedRouteToPath(
           }
         }
       },
-      { inputToken: route.input, path: [], types: [] }
+      { path: [], types: [] }
     )
 
     path = result.path


### PR DESCRIPTION
## What

`encodeMixedRouteToPath` re-derives each hop's output token via:

```ts
const currencyOut = currencyIn.equals(pool.token0) ? pool.token1 : pool.token0
```

This silently falls through to `pool.token0` whenever `currencyIn` doesn't exactly match `pool.token0` (by reference/`.equals()`) — which is exactly what happens at a native/wrapped currency boundary, where `MixedRouteSDK`'s constructor resolves the correct side via a wrapped-equality fallback (`inputToken.wrapped.equals(pool.token0)` etc.), not plain `.equals()`.

Both branches (the v4 branch and the legacy non-v4 fallback) had this same pattern. Both now read each hop's currency directly from `route.path`, which the constructor already resolves correctly — this mirrors the fix already applied to `MixedRouteSDK.midPrice` and `getOutputOfPools` in #706 (ROUTE-886), merged two days before I found this. That PR's own comment states the invariant this fix relies on: `route.path[i + 1]` is always pool `i`'s own currency object.

## Why the existing 20 fixtures never caught it

Every non-WETH token address used in the existing test fixtures (`0x...0001`, `0x...0002`, `0x...0003`) happens to sort **below** WETH's real address (`0xC02aaa39...`). Since there are only two tokens per pool, and the fallthrough always returns `pool.token0`, whenever the "other" token happens to be `token0` (i.e. sorts below WETH), the fallthrough is coincidentally correct. It's only wrong when the non-WETH token sorts **above** WETH's address — none of the existing fixtures do.

## Repro

```
route: USDC -[V4 pool]-> ETH -[V3 pool, WETH<->USDT]-> USDT
route.path (constructor-resolved, correct): [USDC, ETH, USDT]
route.pathOutput: USDT

BEFORE fix: encoded path terminates at 0xc02aaa...756cc2 (WETH's address)
AFTER  fix: encoded path terminates at 0xdac17f...31ec7  (USDT's address, correct)
```

Confirmed via `git stash` that this is a genuine red-before/green-after — the encoded path silently pointed at the wrong terminal token (a WETH/WETH self-loop in the legacy-branch case tested), not a display nit.

## Consumers

Within this monorepo, `encodeMixedRouteToPath` is used directly by:
- `universal-router-sdk/src/entities/actions/uniswap.ts` — building the actual swap command's `path` argument
- `router-sdk/src/swapRouter.ts` — the legacy swap-router path builder

So this isn't just a latent/unused public export — it's wired into real swap-calldata construction inside the same monorepo. I did not check external consumers (e.g. `smart-order-router`, a separate repo) for how they construct routes that reach this encoder, so I can't speak to how often a real multihop route crosses a native/wrapped boundary at a non-default token ordering in production. What's proven here is the code-level defect and its consequence when it fires: the built swap path targets the wrong pool/token, which would either revert (no such pool) or, worse, route through an unintended pool.

## Testing

- Added two regression tests (one per branch) using a token address that sorts above WETH's, specifically to break the coincidental-correctness case. Both fail on unfixed code with the exact predicted symptom (wrong terminal address / WETH self-loop) and pass after the fix — confirmed via `git stash`.
- All 20 pre-existing fixtures remain byte-identical (regenerated and diffed, zero drift).
- Full package suite: 374/374 passing (`bun test`).
- `tsc --noEmit` clean.
- `bun run lint` currently fails on unmodified `main` too (`ESLint: ... all files matching the glob are ignored`) — confirmed via `git stash` that this is a pre-existing repo/tooling issue, not something this PR introduced or needs to fix.

## Codex review

Ran Codex adversarially (synchronous, own tracked PID). It did not return a verdict within ~7 minutes — killed the tracked PID cleanly (confirmed no lingering process) and did a thorough self-review instead, covering: semantic correctness of both branches (verified via the real repro above), whether `route.path` can ever have an unexpected length relative to `route.pools` (no — the constructor always pushes exactly one entry per pool after the initial `pathInput`, so `route.path.length === route.pools.length + 1` by construction, and `route.path[i+1]` is always in bounds), whether the new tests are non-vacuous (confirmed via stash-based red-before/green-after), and whether any existing behavior regressed (confirmed via the full 374-test suite and byte-identical existing fixtures).

Draft opened and flipped to ready per my usual workflow — real command output above, not descriptions.
