### PR TITLE
fix: V4_POSITION_MANAGER_CALL parsed with the wrong decoder

### DIFF
--- a/.changeset/fix-v4-position-manager-call-parser.md
+++ b/.changeset/fix-v4-position-manager-call-parser.md
@@ -1,0 +1,7 @@
+---
+"@uniswap/universal-router-sdk": patch
+---
+
+Fix `CommandParser` throwing on `V4_POSITION_MANAGER_CALL` (command `0x14`). Its real on-chain calldata is a full `modifyLiquidities(bytes,uint256)` function call (selector-prefixed), not the raw `(bytes actions, bytes[] params)` tuple `V4_SWAP` uses, so decoding it via the V4 actions parser threw an overflow error. It's now parsed opaquely, matching `V3_POSITION_MANAGER_CALL`.
+
+Also fixes a related bug in the opaque command parser (`Parser.V3Actions`): it returned every command's raw input for each opaque command in a route instead of just its own.

--- a/sdks/universal-router-sdk/src/utils/commandParser.ts
+++ b/sdks/universal-router-sdk/src/utils/commandParser.ts
@@ -115,7 +115,7 @@ export class GenericCommandParser {
           return {
             commandName: CommandType[commandType],
             commandType,
-            params: inputs.map((input) => ({ name: 'command', value: input })),
+            params: [{ name: 'command', value: inputs[i] }],
           }
         } else {
           throw new Error(`Unsupported parser: ${commandDef}`)

--- a/sdks/universal-router-sdk/src/utils/routerCommands.ts
+++ b/sdks/universal-router-sdk/src/utils/routerCommands.ts
@@ -240,7 +240,7 @@ export const COMMAND_DEFINITION: { [key in CommandType]: CommandDefinition } = {
   // Position Actions
   [CommandType.V3_POSITION_MANAGER_PERMIT]: { parser: Parser.V3Actions },
   [CommandType.V3_POSITION_MANAGER_CALL]: { parser: Parser.V3Actions },
-  [CommandType.V4_POSITION_MANAGER_CALL]: { parser: Parser.V4Actions },
+  [CommandType.V4_POSITION_MANAGER_CALL]: { parser: Parser.V3Actions },
 
   // 3rd Party Integrations
   [CommandType.ACROSS_V4_DEPOSIT_V3]: {

--- a/sdks/universal-router-sdk/test/utils/commandParser.test.ts
+++ b/sdks/universal-router-sdk/test/utils/commandParser.test.ts
@@ -12,6 +12,12 @@ import { WETH, USDC as USDC_DATA, DAI, makeV4Pool, swapOptions } from './uniswap
 
 const addressOne = '0x0000000000000000000000000000000000000001'
 const addressTwo = '0x0000000000000000000000000000000000000002'
+// Mirrors the real V4 PositionManager function UniversalRouter's Dispatcher.sol targets for
+// V4_POSITION_MANAGER_CALL (`address(V4_POSITION_MANAGER).call(inputs)`), so the test input matches
+// real on-chain calldata shape rather than the raw V4Planner actions/params tuple V4_SWAP uses.
+const MODIFY_LIQUIDITIES_INTERFACE = new ethers.utils.Interface([
+  'function modifyLiquidities(bytes unlockData, uint256 deadline)',
+])
 const amount = ethers.utils.parseEther('1')
 const TICKLIST = [
   {
@@ -450,10 +456,17 @@ describe('Command Parser', () => {
       },
     },
     {
+      // V4_POSITION_MANAGER_CALL's real on-chain calldata is a full `modifyLiquidities(bytes,uint256)`
+      // call (see UniversalRouter's Dispatcher.sol: `V4_POSITION_MANAGER.call(inputs)`), not the raw
+      // (bytes actions, bytes[] params) tuple that V4_SWAP uses. It must be parsed opaquely, matching
+      // V3_POSITION_MANAGER_CALL, since the SDK does not decode a full function call for this command.
       input: new RoutePlanner().addCommand(CommandType.V4_POSITION_MANAGER_CALL, [
-        new V4Planner()
-          .addAction(Actions.MINT_POSITION, [USDC_WETH.poolKey, -60, 60, 5000000, amount, amount, addressOne, '0x'])
-          .finalize(),
+        MODIFY_LIQUIDITIES_INTERFACE.encodeFunctionData('modifyLiquidities', [
+          new V4Planner()
+            .addAction(Actions.MINT_POSITION, [USDC_WETH.poolKey, -60, 60, 5000000, amount, amount, addressOne, '0x'])
+            .finalize(),
+          ethers.constants.MaxUint256,
+        ]),
       ]),
       result: {
         commands: [
@@ -462,43 +475,52 @@ describe('Command Parser', () => {
             commandType: CommandType.V4_POSITION_MANAGER_CALL,
             params: [
               {
-                name: 'MINT_POSITION',
-                value: [
-                  {
-                    name: 'poolKey',
-                    value: USDC_WETH.poolKey,
-                  },
-                  {
-                    name: 'tickLower',
-                    value: -60,
-                  },
-                  {
-                    name: 'tickUpper',
-                    value: 60,
-                  },
-                  {
-                    name: 'liquidity',
-                    value: BigNumber.from(5000000),
-                  },
-                  {
-                    name: 'amount0Max',
-                    value: amount,
-                  },
-                  {
-                    name: 'amount1Max',
-                    value: amount,
-                  },
-                  {
-                    name: 'owner',
-                    value: addressOne,
-                  },
-                  {
-                    name: 'hookData',
-                    value: '0x',
-                  },
-                ],
+                name: 'command',
+                value: MODIFY_LIQUIDITIES_INTERFACE.encodeFunctionData('modifyLiquidities', [
+                  new V4Planner()
+                    .addAction(Actions.MINT_POSITION, [
+                      USDC_WETH.poolKey,
+                      -60,
+                      60,
+                      5000000,
+                      amount,
+                      amount,
+                      addressOne,
+                      '0x',
+                    ])
+                    .finalize(),
+                  ethers.constants.MaxUint256,
+                ]),
               },
             ],
+          },
+        ],
+      },
+    },
+    {
+      // Regression test: the opaque (Parser.V3Actions) branch used to return `inputs.map(...)`,
+      // i.e. every command's raw input, for each opaque command in the route. Mixing three opaque
+      // commands with distinct calldata here proves each one now reports only its own input.
+      input: new RoutePlanner()
+        .addCommand(CommandType.V3_POSITION_MANAGER_PERMIT, ['0x1111111111111111'])
+        .addCommand(CommandType.V3_POSITION_MANAGER_CALL, ['0x2222222222222222'])
+        .addCommand(CommandType.V4_POSITION_MANAGER_CALL, ['0x3333333333333333']),
+      result: {
+        commands: [
+          {
+            commandName: 'V3_POSITION_MANAGER_PERMIT',
+            commandType: CommandType.V3_POSITION_MANAGER_PERMIT,
+            params: [{ name: 'command', value: '0x1111111111111111' }],
+          },
+          {
+            commandName: 'V3_POSITION_MANAGER_CALL',
+            commandType: CommandType.V3_POSITION_MANAGER_CALL,
+            params: [{ name: 'command', value: '0x2222222222222222' }],
+          },
+          {
+            commandName: 'V4_POSITION_MANAGER_CALL',
+            commandType: CommandType.V4_POSITION_MANAGER_CALL,
+            params: [{ name: 'command', value: '0x3333333333333333' }],
           },
         ],
       },


### PR DESCRIPTION
## What's broken

`CommandParser.parseCalldata` throws on any real `V4_POSITION_MANAGER_CALL` (command `0x14`) calldata.

`routerCommands.ts` maps `V4_POSITION_MANAGER_CALL` to `Parser.V4Actions`, which decodes the command's input as a raw `(bytes actions, bytes[] params)` tuple - the shape `V4_SWAP` uses. But on-chain, `Dispatcher.sol` handles this command differently:

```solidity
} else if (command == Commands.V4_POSITION_MANAGER_CALL) {
    // should only call modifyLiquidities() to mint
    _checkV4PositionManagerCall(inputs);
    (success, output) = address(V4_POSITION_MANAGER).call{value: address(this).balance}(inputs);
}
```

`inputs` here is passed straight to `.call()` on the PositionManager - i.e. it's a full, selector-prefixed `modifyLiquidities(bytes,uint256)` function call, not a bare actions/params tuple. `swapRouter.ts` confirms this is exactly what the SDK itself sends:

```ts
const v4AddParams = V4PositionManager.addCallParameters(options.outputPosition, options.v4AddLiquidityOptions)
const selector = v4AddParams.calldata.slice(0, 10)
invariant(selector == V4PositionManager.INTERFACE.getSighash('modifyLiquidities'), 'INVALID_V4_CALL: ' + selector)
planner.addCommand(CommandType.V4_POSITION_MANAGER_CALL, [v4AddParams.calldata])
```

Feeding that selector-prefixed calldata into `defaultAbiCoder.decode(['bytes','bytes[]'], calldata)` (inside `V4BaseActionsParser.parseCalldata`, from `@uniswap/v4-sdk`) throws an ABI overflow error - confirmed with a real repro script encoding a realistic `modifyLiquidities` call and running it through `CommandParser.parseCalldata`.

## Fix

Route `V4_POSITION_MANAGER_CALL` through `Parser.V3Actions` instead (opaque passthrough) - the same parser `V3_POSITION_MANAGER_CALL` already uses, since it has the identical "raw contract call, not an actions/params tuple" shape.

**Encoding is unaffected.** `createCommand`'s switch statement returns `parameters[0]` verbatim for both `Parser.V4Actions` and `Parser.V3Actions` - this is a decode-only fix, already-built or already-signed transactions are untouched.

## Second bug, same code path

While fixing this I found the opaque-parser branch (`Parser.V3Actions`) itself had a bug: it returned `inputs.map((input) => ({ name: 'command', value: input }))` - i.e. **every** command's raw input in the whole route, not just the current command's own input (`inputs[i]`). Harmless for a single-command route (which is all the existing tests exercised), but wrong for any route mixing an opaque command with anything else - and now more likely to matter, since `V4_POSITION_MANAGER_CALL` routes through this same branch. Fixed alongside since it directly affects the correctness of this PR's own fix for realistic multi-command routes.

## Tests

The existing `V4_POSITION_MANAGER_CALL` test was itself part of the problem: it built its input as a raw `V4Planner().finalize()` tuple (no selector) and asserted the old structured `Parser.V4Actions` decode - self-consistent with the bug, but not representative of what `swapRouter.ts` actually sends on-chain. Updated it to build real selector-prefixed `modifyLiquidities` calldata and assert the opaque decode.

Added a new mixed 3-command test (`V3_POSITION_MANAGER_PERMIT` + `V3_POSITION_MANAGER_CALL` + `V4_POSITION_MANAGER_CALL`, each with distinct dummy calldata) to pin the `inputs[i]` fix - confirmed by hand that it fails (`1 failing`) with the old `inputs.map(...)` code and passes (`22 passing`) with the fix.

## receipts

**Ground truth verification** (all read directly, not assumed):
- `UniversalRouter`'s `Dispatcher.sol` (`Uniswap/universal-router`, cloned fresh) - confirmed the `.call(inputs)` shape for `V4_POSITION_MANAGER_CALL` vs. `decodeActionsRouterParams()` for `V4_SWAP`.
- `swapRouter.ts:513-519` - confirmed the SDK's own real caller sends selector-prefixed `modifyLiquidities` calldata, with an explicit selector-check invariant.
- `v4BaseActionsParser.ts` - confirmed the actual throwing decode call (`defaultAbiCoder.decode(['bytes','bytes[]'], calldata)`).
- `routerCommands.ts`'s `createCommand` - confirmed encode-side treats both parser tags identically (`parameters[0]` passthrough), so this is safe as a decode-only change.

**Real executable repro** (before fix), building realistic `modifyLiquidities` calldata via `ethers.utils.Interface`:
```
Error: overflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow ]
(fault="overflow", operation="toNumber", ...)
```

**Test suite** (`npx hardhat test test/utils/commandParser.test.ts`), before/after the `inputs[i]` fix specifically:
```
# with the old `inputs.map(...)` bug reintroduced:
  21 passing (54ms)
  1 failing

# with the fix restored:
  22 passing (55ms)
```

Full suite, final state: **22 passing, 0 failing.**

`bun run build` (tsc, all three target configs) - clean, no errors.
`bun run prettier -- --check` on all changed files - clean.

(One unrelated, pre-existing item: the hardhat test runner exits with code 1 due to `[Error: relative URL without a base]` during teardown, after all tests report passing. Confirmed via `git stash` that this happens identically on unmodified `upstream/main` - unrelated to this diff, a local/environment hardhat-plugin quirk, not a real test failure.)

Added a changeset (`patch` for `@uniswap/universal-router-sdk`).

## Risk

Low. Decode-only change, scoped to a single command type that currently cannot be parsed at all (100% failure rate on real calldata) plus a same-file adjacent bug fix. Encode side is provably untouched.